### PR TITLE
EAGLE-94 Add shebang in eagle-lib.sh

### DIFF
--- a/eagle-external/eagle-docker/bin/eagle-lib.sh
+++ b/eagle-external/eagle-docker/bin/eagle-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-94

Add Shebang in eagle-lib.sh to fix the bug that eagle-lib.sh cannot be sourced in Mac.