### PR TITLE
https://issues.apache.org/jira/browse/EAGLE-104

### DIFF
--- a/eagle-samples/pom.xml
+++ b/eagle-samples/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/eagle-security/eagle-security-common/src/main/java/org/apache/eagle/security/util/LogParseUtil.java
+++ b/eagle-security/eagle-security-common/src/main/java/org/apache/eagle/security/util/LogParseUtil.java
@@ -28,8 +28,14 @@ public class LogParseUtil {
      * 2)hadoop/123.dc1.xyz.com@xyz.com (auth:KERBEROS)
      * 3)hadoop (auth:KERBEROS)
      */
-    public static String parseUserFromUGI(String ugi) {
-      if(ugi == null) return null;
-      return (ugi.trim().split("[/@(]"))[0];
+    public static String parseUserFromUGI(String newUgi) {
+        if(newUgi == null) return null;
+        int index = newUgi.indexOf("/");
+        if (index != -1) return newUgi.substring(0, index);
+        index = newUgi.indexOf("@");
+        if (index != -1) return newUgi.substring(0, index);
+        index = newUgi.indexOf("(");
+        if (index != -1) return newUgi.substring(0, index).trim();
+        return newUgi.trim();
     }
 }

--- a/eagle-security/eagle-security-common/src/main/java/org/apache/eagle/security/util/LogParseUtil.java
+++ b/eagle-security/eagle-security-common/src/main/java/org/apache/eagle/security/util/LogParseUtil.java
@@ -29,13 +29,7 @@ public class LogParseUtil {
      * 3)hadoop (auth:KERBEROS)
      */
     public static String parseUserFromUGI(String ugi) {
-        if(ugi == null) return null;
-        String newUgi = ugi.trim();
-        int index = newUgi.indexOf("/");
-        if (index != -1) return newUgi.substring(0, index).trim();
-        index = newUgi.indexOf("@");
-        if (index != -1) return newUgi.substring(0, index).trim();
-        index = newUgi.indexOf("(");
-        return newUgi.substring(0, index).trim();
+      if(ugi == null) return null;
+      return (ugi.trim().split("[/@(]"))[0];
     }
 }

--- a/eagle-security/eagle-security-hdfs-securitylog/src/test/java/org/apache/eagle/security/TestHDFSSecuritylogParser.java
+++ b/eagle-security/eagle-security-hdfs-securitylog/src/test/java/org/apache/eagle/security/TestHDFSSecuritylogParser.java
@@ -28,14 +28,42 @@ import java.text.ParseException;
 
 public class TestHDFSSecuritylogParser {
 
+  /**
+   * Test success log message with simple auth
+   * @throws ParseException
+   */
     @Test
-    public void test() throws ParseException {
-        String msg = "2015-11-18 08:41:10,200 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for hbase (auth:SIMPLE) for protocol=interface org.apache.hadoop.hdfs.protocol.ClientProtocol";
+    public void testSimpleAuth() throws ParseException {
+      String msg = "2015-11-18 08:41:10,200 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for hbase (auth:SIMPLE) for protocol=interface org.apache.hadoop.hdfs.protocol.ClientProtocol";
+      verifyParserAttributes(msg);
+    }
 
-        HDFSSecurityLogParser parser = new HDFSSecurityLogParser();
-        HDFSSecurityLogObject obj = parser.parse(msg);
+    /**
+     * Test success log message with kerberos auth for service principal
+     * @throws ParseException
+     */
+    @Test
+    public void testServicePrincipalAuth() throws ParseException {
+      String msg = "2015-12-22 17:07:03,359 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for hbase/node1.foo.com@EXAMPLE.COM (auth:KERBEROS) for protocol=interface org.apache.hadoop.hdfs.protocol.ClientProtocol";
+      verifyParserAttributes(msg);
+    }
 
-        Assert.assertEquals("hbase", obj.user);
-        Assert.assertEquals(true, obj.allowed);
+    /**
+     * Test success log message with kerberos auth for user principal
+     * @throws ParseException
+     */
+    @Test
+    public void testUserPrincipalAuth() throws ParseException {
+      String msg = "2015-12-22 17:07:03,359 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for hbase@EXAMPLE.COM (auth:KERBEROS) for protocol=interface org.apache.hadoop.hdfs.protocol.ClientProtocol";
+      verifyParserAttributes(msg);
+    }
+
+    private void verifyParserAttributes(String logMessage) throws ParseException {
+      HDFSSecurityLogParser parser = new HDFSSecurityLogParser();
+      HDFSSecurityLogObject obj = parser.parse(logMessage);
+
+      Assert.assertEquals("hbase", obj.user);
+      Assert.assertEquals(true, obj.allowed);
+
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -892,6 +892,7 @@
                                 <exclude>**/*.log</exclude>
                                 <exclude>**/eagle.log*</exclude>
                                 <exclude>**/resources/**/*.json</exclude>
+                                <exclude>**/resources/eagle.siddhiext</exclude>
                                 <exclude>**/test/resources/securityAuditLog</exclude>
                                 <exclude>**/resources/**/ml-policyDef-UserProfile.txt</exclude>
                                 <exclude>**/test/resources/onelinehiveauditlog.txt</exclude>


### PR DESCRIPTION
EAGLE-104: Fix the unit test TestHDFSSecuritylogParser
The problem is that the UGI parsing method is not handling the simple authentication scenario where user name is not a kerberos principal. The patch is a minor refactoring of the method that parses the ugi.
Added new testcases to validate the changes.  Ran unit tests, no failures in eagle-security.
