### PR TITLE
EAGLE-114: Enable RAT check and fix missing license headers

### DIFF
--- a/eagle-assembly/src/main/README.md
+++ b/eagle-assembly/src/main/README.md
@@ -1,3 +1,5 @@
+<!--
+{% comment %}
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{% endcomment %}
+-->
 
 Eagle User Guide
 ========================

--- a/eagle-assembly/src/main/README.md
+++ b/eagle-assembly/src/main/README.md
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 Eagle User Guide
 ========================
 

--- a/eagle-assembly/src/main/docs/logstash-kafka-conf.md
+++ b/eagle-assembly/src/main/docs/logstash-kafka-conf.md
@@ -1,3 +1,5 @@
+<!--
+{% comment %}
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{% endcomment %}
+-->
 
 # Logstash-kafka 
 

--- a/eagle-assembly/src/main/docs/logstash-kafka-conf.md
+++ b/eagle-assembly/src/main/docs/logstash-kafka-conf.md
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Logstash-kafka 
 
 ### Install logstash-kafka plugin

--- a/eagle-external/eagle-ambari/README.md
+++ b/eagle-external/eagle-ambari/README.md
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 eagle-ambari-plugin
 ===================
 

--- a/eagle-external/eagle-ambari/README.md
+++ b/eagle-external/eagle-ambari/README.md
@@ -1,3 +1,5 @@
+<!--
+{% comment %}
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{% endcomment %}
+-->
 
 eagle-ambari-plugin
 ===================

--- a/eagle-external/eagle-ambari/lib/EAGLE/configuration/eagle-env.sh
+++ b/eagle-external/eagle-ambari/lib/EAGLE/configuration/eagle-env.sh
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/eagle-external/eagle-ambari/lib/EAGLE/configuration/eagle-service.conf
+++ b/eagle-external/eagle-ambari/lib/EAGLE/configuration/eagle-service.conf
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 env=test
 
 eagle.storage.type=hbase

--- a/eagle-security/eagle-metric-collection/src/main/resources/application.conf
+++ b/eagle-security/eagle-metric-collection/src/main/resources/application.conf
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#   
+#    http://www.apache.org/licenses/LICENSE-2.0
+#   
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {
   "envContextConfig" : {
     "env" : "storm",

--- a/eagle-security/eagle-security-hive/run_hiveauditlog_topology.sh
+++ b/eagle-security/eagle-security-hive/run_hiveauditlog_topology.sh
@@ -1,2 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/1.6.0_65-b14-462.jdk/Contents/Home
 mvn -X exec:java -Dexec.mainClass="eagle.security.hive.HiveAuditLogProcessorMain"

--- a/eagle-security/eagle-security-hive/src/assembly/eagle-dam-hiveQueryLog-assembly.xml
+++ b/eagle-security/eagle-security-hive/src/assembly/eagle-dam-hiveQueryLog-assembly.xml
@@ -1,3 +1,19 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">

--- a/eagle-security/eagle-security-hive/src/main/resources/alert-metadata-create-jobhistory.sh
+++ b/eagle-security/eagle-security-hive/src/main/resources/alert-metadata-create-jobhistory.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #### AlertStreamService: alert streams generated from data source
 curl -X POST -H 'Content-Type:application/json' "http://localhost:38080/eagle-service/rest/entities?serviceName=AlertStreamService" -d '[{"prefix":"alertStream","tags":{"dataSource":"hiveQueryLog","streamName":"hiveAccessLogStream"},"desc":"alert event stream from hive query"}]'
 

--- a/eagle-security/eagle-security-hive/src/main/resources/create-hiveResourceSensitivity-metadata.sh
+++ b/eagle-security/eagle-security-hive/src/main/resources/create-hiveResourceSensitivity-metadata.sh
@@ -1,3 +1,18 @@
 #!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #### HiveResourceSensitivityService
 curl -X POST -H 'Content-Type:application/json' "http://localhost:38080/eagle-service/rest/entities?serviceName=HiveResourceSensitivityService" -d '[{"prefix":"hiveResourceSensitivity","tags":{"hiveResource":"xademo.customer_details.phone_number"},"sensitivityType":"PHONE_NUMBER"}]'

--- a/eagle-security/eagle-security-hive/src/main/resources/hive.storm.yaml
+++ b/eagle-security/eagle-security-hive/src/main/resources/hive.storm.yaml
@@ -1,1 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 topology.workers: 3

--- a/eagle-security/eagle-security-hive/src/main/resources/sample-data-create.script
+++ b/eagle-security/eagle-security-hive/src/main/resources/sample-data-create.script
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ##### create table:  hive resource sensitivity metadata to define what type of sensitivity one hive resource contains
 create 'hiveResourceSensitivity', {NAME => 'f', VERSIONS => '3', BLOOMFILTER => 'ROW', COMPRESSION => 'SNAPPY'}
 

--- a/eagle-security/eagle-security-hive/src/main/resources/sample-hive-policy.sh
+++ b/eagle-security/eagle-security-hive/src/main/resources/sample-hive-policy.sh
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #curl -X POST -H 'Content-Type:application/json' "http://localhost:9099/eagle-service/rest/entities?serviceName=AlertDefinitionService" -d '[{"tags":{"site":"sandbox","dataSource":"hiveQueryLogFromRunningJob","policyId":"accessSensitiveResource","alertExecutorId":"hiveAccessAlertByJobHistory","policyType":"siddhiCEPEngine"},"desc":"alert when some users access sensitive hive resource","policyDef":"{\"type\":\"siddhiCEPEngine\",\"expression\":\"from hiveAccessLogStream[user=='userxyz' and sensitivityType=='PHONE_NUMBER'] select user,timestamp,resource,sensitivityType insert into outputStream ;\"}","dedupeDef":"","notificationDef":"","remediationDef":"","enabled":true}]'
 #curl -X POST -H 'Content-Type:application/json' "http://localhost:9099/eagle-service/rest/entities?serviceName=AlertDefinitionService" -d '[{"tags":{"site":"sandbox","dataSource":"hiveQueryLog","policyId":"accessSensitiveResource","alertExecutorId":"hiveAccessAlertByRunningJob","policyType":"siddhiCEPEngine"},"desc":"alert when some users access sensitive hive resource","policyDef":"{\"type\":\"siddhiCEPEngine\",\"expression\":\"from hiveAccessLogStream[sensitivityType=='\'PHONE_NUMBER\''] select user,timestamp,resource,sensitivityType insert into outputStream ;\"}","dedupeDef":"","notificationDef":"","remediationDef":"","enabled":true}]'
 curl -X POST -H 'Content-Type:application/json' "http://localhost:9099/eagle-service/rest/entities?serviceName=AlertDefinitionService" -d '[{"tags":{"site":"sandbox","dataSource":"hiveQueryLog","policyId":"accessSensitiveResource","alertExecutorId":"hiveAccessAlertByRunningJob","policyType":"siddhiCEPEngine"},"desc":"alert when some users access sensitive hive resource","policyDef":"{\"type\":\"siddhiCEPEngine\",\"expression\":\"from hiveAccessLogStream[user=='\'userxyz\'' and sensitivityType=='\'PHONE_NUMBER\''] select user,timestamp,resource,sensitivityType insert into outputStream ;\"}","dedupeDef":"","notificationDef":"","remediationDef":"","enabled":true}]'

--- a/eagle-security/eagle-security-userprofile/detection/dev-supports/prepare-metadata.sh
+++ b/eagle-security/eagle-security-userprofile/detection/dev-supports/prepare-metadata.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 export SERVICE_HOST="localhost"
 export SERVICE_PORT=9099
 

--- a/eagle-security/eagle-security-userprofile/detection/dev-supports/prepare-table.sh
+++ b/eagle-security/eagle-security-userprofile/detection/dev-supports/prepare-table.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 create 'alertStreamSchema', {NAME => 'f', BLOOMFILTER => 'ROW', VERSIONS => '1', COMPRESSION => 'SNAPPY'}
 create 'mlmodel', {NAME => 'f', BLOOMFILTER => 'ROW', VERSIONS => '1', COMPRESSION => 'SNAPPY'}
 create 'eagle_metric', {NAME => 'f', BLOOMFILTER => 'ROW', VERSIONS => '1', COMPRESSION => 'SNAPPY'}

--- a/eagle-security/eagle-security-userprofile/detection/dev-supports/produce-useractivity-with-spark.sh
+++ b/eagle-security/eagle-security-userprofile/detection/dev-supports/produce-useractivity-with-spark.sh
@@ -1,3 +1,18 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 spark-submit --master yarn-cluster --deploy-mode cluster --class eagle.security.userprofile.UserProfileTrainingCLI eagle-security-userprofile-training-0.1.0-assembly.jar --master yarn-cluster --period PT1M --input /tmp/auditlog/* --kafka-props topic=sandbox_hdfs_audit_agg,metadata.broker.list=sandbox.hortonworks.com:6667

--- a/eagle-security/eagle-security-userprofile/detection/dev-supports/produce-useractivity.sh
+++ b/eagle-security/eagle-security-userprofile/detection/dev-supports/produce-useractivity.sh
@@ -1,3 +1,18 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 /usr/hdp/current/kafka-broker/bin/kafka-console-producer.sh --broker-list sandbox.hortonworks.com:6667 --topic sandbox_hdfs_audit_agg

--- a/eagle-security/eagle-security-userprofile/detection/run_onlineprediction_topology.sh
+++ b/eagle-security/eagle-security-userprofile/detection/run_onlineprediction_topology.sh
@@ -1,3 +1,19 @@
 #!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 export JAVA_HOME=$(/usr/libexec/java_home -v 1.6)
 mvn -X exec:java -Dexec.mainClass="eagle.security.userprofile.UserProfileDetectionAnomalyRunner"

--- a/eagle-security/eagle-security-userprofile/detection/src/main/java/org/apache/eagle/security/userprofile/UserProfileDetectionMain.java
+++ b/eagle-security/eagle-security-userprofile/detection/src/main/java/org/apache/eagle/security/userprofile/UserProfileDetectionMain.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ */
 package org.apache.eagle.security.userprofile;
 
 import com.typesafe.config.Config;

--- a/eagle-security/eagle-security-userprofile/detection/src/main/resources/userprofile.storm.yaml
+++ b/eagle-security/eagle-security-userprofile/detection/src/main/resources/userprofile.storm.yaml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 ### topology.* configs are for specific executing storms
 topology.enable.message.timeouts: true
 topology.debug: false

--- a/eagle-security/eagle-security-userprofile/detection/src/test/java/org/apache/eagle/security/userprofile/TestUserActivityAggregator.java
+++ b/eagle-security/eagle-security-userprofile/detection/src/test/java/org/apache/eagle/security/userprofile/TestUserActivityAggregator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ */
 package org.apache.eagle.security.userprofile;
 
 import org.apache.eagle.common.DateTimeUtil;

--- a/eagle-security/eagle-security-userprofile/detection/src/test/java/org/apache/eagle/security/userprofile/TestUserProfileAnomalyEigenEvaluator.java
+++ b/eagle-security/eagle-security-userprofile/detection/src/test/java/org/apache/eagle/security/userprofile/TestUserProfileAnomalyEigenEvaluator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ */
 package org.apache.eagle.security.userprofile;
 
 import org.apache.eagle.ml.model.MLCallbackResult;

--- a/eagle-security/eagle-security-userprofile/training/src/main/java/org/apache/eagle/security/userprofile/model/JavaUserProfileModeler.java
+++ b/eagle-security/eagle-security-userprofile/training/src/main/java/org/apache/eagle/security/userprofile/model/JavaUserProfileModeler.java
@@ -1,3 +1,23 @@
+/*
+ * 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ */
 package org.apache.eagle.security.userprofile.model;
 
 import org.apache.commons.math3.linear.RealMatrix;

--- a/eagle-security/eagle-security-userprofile/training/src/main/resources/reference.conf
+++ b/eagle-security/eagle-security-userprofile/training/src/main/resources/reference.conf
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 akka {
 
 	# Loggers to register at boot time (akka.event.Logging$DefaultLogger logs

--- a/eagle-security/eagle-security-userprofile/training/src/main/sbin/submit-userprofile-training.sh
+++ b/eagle-security/eagle-security-userprofile/training/src/main/sbin/submit-userprofile-training.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd $(dirname $0)/../
 
 ./bin/submit-userprofile-training.sh --master yarn-cluster \

--- a/eagle-topology-assembly/src/assembly/eagle-topology-assembly.xml
+++ b/eagle-topology-assembly/src/assembly/eagle-topology-assembly.xml
@@ -1,3 +1,20 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -852,6 +852,71 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>header-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <!-- Git specific files -->
+                                <exclude>.git/</exclude>
+                                <exclude>.java-version</exclude>
+                                <exclude>.gitignore</exclude>
+                                <!-- IDE specific files-->
+                                <exclude>**/.idea/</exclude>
+                                <exclude>**/.scalastyle/</exclude>
+                                <exclude>**/*.iml</exclude>
+                                <exclude>**/nb-configuration.xml</exclude>
+                                <exclude>**/.classpath</exclude>
+                                <exclude>**/.settings/**</exclude>
+                                <exclude>**/.project</exclude>
+                                <exclude>**/.metadata/</exclude>
+                                <!-- Maven working directory -->
+                                <exclude>**/target/**</exclude>
+                                <!-- Patch files which can be lying around -->
+                                <exclude>**/*.patch</exclude>
+                                <exclude>**/*.rej</exclude>
+                                <!-- Exclude generated files -->
+                                <exclude>**/gen/**</exclude>
+                                <!-- README and test data with exact format -->
+                                <exclude>README*</exclude>
+                                <exclude>**/*.log</exclude>
+                                <exclude>**/eagle.log*</exclude>
+                                <exclude>**/resources/**/*.json</exclude>
+                                <exclude>**/test/resources/securityAuditLog</exclude>
+                                <exclude>**/resources/**/ml-policyDef-UserProfile.txt</exclude>
+                                <exclude>**/test/resources/onelinehiveauditlog.txt</exclude>
+                                <exclude>**/test/resources/ranger-policy-update-request.txt</exclude>
+                                <exclude>**/dev-supports/**/*.json</exclude>
+                                <exclude>**/dev-supports/**/useractivity-agg-json.txt</exclude>
+                                <exclude>**/conf/sandbox-userprofile-topology.conf</exclude>
+                                <!-- Fonts and Images -->
+                                <exclude>**/fonts/**</exclude>
+                                <exclude>**/images/**</exclude>
+                                <exclude>**/lib/js/**</exclude>
+                                <exclude>**/lib/css/**</exclude>
+                                <exclude>**/*.min.js</exclude>
+                                <exclude>**/jquery-*.js</exclude>
+                                <exclude>**/MANIFEST.MF</exclude>
+                                <!-- External dependency script -->
+                                <exclude>**/resource/serf/etc/ambari.json</exclude>
+
+                                <!-- TODO: fix it -->
+                                <exclude>**/webapp/**</exclude>
+
+                            </excludes>
+                         </configuration>
+                     </execution>
+                 </executions>
+             </plugin>
+         </plugins>
     </build>
     <repositories>
         <repository>


### PR DESCRIPTION
Enable rat check in pom
Added missing headers in java sources, shell scripts, config and doc files. Some of the test files and json files are excluded since these formats don't support comments.
The files under webapp in eagle-webservice module are deferred in this patch. Those will tracked in a separate patch.
Compilation, rat check (via maven verify) and unit tests pass with the patch.