### PR TITLE
EAGLE-39 Policy State Management

### DIFF
--- a/eagle-core/eagle-alert/eagle-alert-process/pom.xml
+++ b/eagle-core/eagle-alert/eagle-alert-process/pom.xml
@@ -32,6 +32,11 @@
     <dependencies>
         <dependency>
             <groupId>eagle</groupId>
+            <artifactId>eagle-executor-state</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eagle</groupId>
     		<artifactId>eagle-embed-server</artifactId>
     		<version>${project.version}</version>
             <scope>test</scope>

--- a/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/alert/siddhi/SiddhiAlertHandler.java
+++ b/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/alert/siddhi/SiddhiAlertHandler.java
@@ -21,6 +21,10 @@ import org.apache.eagle.alert.entity.AlertAPIEntity;
 import java.util.List;
 
 public interface SiddhiAlertHandler {
-
+    /**
+     * Siddhi evaluate events in another thread other than the thread where event is sent.
+     * @param context
+     * @param alerts
+     */
 	void onAlerts(EagleAlertContext context, List<AlertAPIEntity> alerts);
 }

--- a/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/AlertExecutorCreationUtils.java
+++ b/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/AlertExecutorCreationUtils.java
@@ -76,7 +76,7 @@ public class AlertExecutorCreationUtils {
     }
 
     /**
-     * Build DAG Tasks based on persisted alert definition and schemas from eagle store.
+     * Build DAG Tasks based on persisted alert definition and schemas from eagle writeState.
      *
      * <h3>Require configuration:</h3>
      *

--- a/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/PolicyStatsReporter.java
+++ b/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/PolicyStatsReporter.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.executor;
+
+/**
+ * interface for reporting policy statistics including
+ * 1. # of incoming events
+ * 2. # of evaluated polices
+ * 3. # of failures in policy evaluation
+ * 4. # of alerts
+ */
+public interface PolicyStatsReporter {
+    public final static String EAGLE_EVENT_COUNT = "eagle.event.count";
+    public final static String EAGLE_POLICY_EVAL_COUNT = "eagle.policy.eval.count";
+    public final static String EAGLE_POLICY_EVAL_FAIL_COUNT = "eagle.policy.eval.fail.count";
+    public final static String EAGLE_ALERT_COUNT = "eagle.alert.count";
+    void incrIncomingEvent();
+    void incrPolicyEvaluation(String policyId);
+    void incrPolicyEvaluationFailure(String policyId);
+    void incrAlert(String policyId, int occurrences);
+}

--- a/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/PolicyStatsReporterImpl.java
+++ b/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/PolicyStatsReporterImpl.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.executor;
+
+import com.codahale.metrics.MetricRegistry;
+import com.typesafe.config.Config;
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.eagle.alert.common.AlertConstants;
+import org.apache.eagle.common.config.EagleConfigConstants;
+import org.apache.eagle.metric.reportor.EagleCounterMetric;
+import org.apache.eagle.metric.reportor.EagleMetricListener;
+import org.apache.eagle.metric.reportor.EagleServiceReporterMetricListener;
+import org.apache.eagle.metric.reportor.MetricKeyCodeDecoder;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class to report policy evaluation statistics
+ */
+public class PolicyStatsReporterImpl implements PolicyStatsReporter{
+    private	static long MERITE_GRANULARITY = DateUtils.MILLIS_PER_MINUTE;
+    private Map<String, Map<String, String>> dimensionsMap; // cache it for performance
+    private Map<String, String> baseDimensions;
+    private EagleMetricListener listener;
+
+    private MetricRegistry registry;
+
+    @Override
+    public void incrIncomingEvent() {
+        updateCounter(EAGLE_EVENT_COUNT, baseDimensions);
+    }
+
+    @Override
+    public void incrPolicyEvaluation(String policyId) {
+        updateCounter(EAGLE_POLICY_EVAL_COUNT, getDimensions(policyId));
+    }
+
+    @Override
+    public void incrPolicyEvaluationFailure(String policyId) {
+        updateCounter(EAGLE_POLICY_EVAL_FAIL_COUNT, getDimensions(policyId));
+    }
+
+    @Override
+    public void incrAlert(String policyId, int occurrences) {
+        updateCounter(EAGLE_ALERT_COUNT, getDimensions(policyId), occurrences);
+    }
+
+    public PolicyStatsReporterImpl(Config config, String alertExecutorId, int partitionSeq){
+        String host = config.getString(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.EAGLE_SERVICE + "." + EagleConfigConstants.HOST);
+        int port = config.getInt(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.EAGLE_SERVICE + "." + EagleConfigConstants.PORT);
+
+        String username = config.hasPath(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.EAGLE_SERVICE + "." + EagleConfigConstants.USERNAME) ?
+                config.getString(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.EAGLE_SERVICE + "." + EagleConfigConstants.USERNAME) : null;
+        String password = config.hasPath(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.EAGLE_SERVICE + "." + EagleConfigConstants.PASSWORD) ?
+                config.getString(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.EAGLE_SERVICE + "." + EagleConfigConstants.PASSWORD) : null;
+
+        //TODO: need to it replace it with batch flush listener
+        registry = new MetricRegistry();
+        listener = new EagleServiceReporterMetricListener(host, port, username, password);
+
+        baseDimensions = new HashMap<>();
+        baseDimensions.put(AlertConstants.ALERT_EXECUTOR_ID, alertExecutorId);
+        baseDimensions.put(AlertConstants.PARTITIONSEQ, String.valueOf(partitionSeq));
+        baseDimensions.put(AlertConstants.SOURCE, ManagementFactory.getRuntimeMXBean().getName());
+        baseDimensions.put(EagleConfigConstants.DATA_SOURCE, config.getString(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.DATA_SOURCE));
+        baseDimensions.put(EagleConfigConstants.SITE, config.getString(EagleConfigConstants.EAGLE_PROPS + "." + EagleConfigConstants.SITE));
+        dimensionsMap = new HashMap<>();
+    }
+
+    private void updateCounter(String name, Map<String, String> dimensions, double value) {
+        long current = System.currentTimeMillis();
+        String metricName = MetricKeyCodeDecoder.codeMetricKey(name, dimensions);
+        if (registry.getMetrics().get(metricName) == null) {
+            EagleCounterMetric metric = new EagleCounterMetric(current, metricName, value, MERITE_GRANULARITY);
+            metric.registerListener(listener);
+            registry.register(metricName, metric);
+        } else {
+            EagleCounterMetric metric = (EagleCounterMetric) registry.getMetrics().get(metricName);
+            metric.update(value, current);
+            //TODO: need remove unused metric from registry
+        }
+    }
+
+    private void updateCounter(String name, Map<String, String> dimensions) {
+        updateCounter(name, dimensions, 1.0);
+    }
+
+    private Map<String, String> getDimensions(String policyId) {
+        if (dimensionsMap.get(policyId) == null) {
+            Map<String, String> newDimensions = new HashMap<String, String>(baseDimensions);
+            newDimensions.put(AlertConstants.POLICY_ID, policyId);
+            dimensionsMap.put(policyId, newDimensions);
+        }
+        return dimensionsMap.get(policyId);
+    }
+}

--- a/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/PolicyStatsReporters.java
+++ b/eagle-core/eagle-alert/eagle-alert-process/src/main/java/org/apache/eagle/executor/PolicyStatsReporters.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.executor;
+
+import com.typesafe.config.Config;
+
+/**
+ * Utility class to instantiate PolicyStatsReporter
+ */
+public class PolicyStatsReporters {
+    public static PolicyStatsReporter newReporter(Config config, String alertExecutorId, int partitionSeq){
+        return new PolicyStatsReporterImpl(config, alertExecutorId, partitionSeq);
+    }
+}

--- a/eagle-core/eagle-alert/eagle-alert-process/src/test/java/org/apache/eagle/alert/cep/TestAlertExecutor.java
+++ b/eagle-core/eagle-alert/eagle-alert-process/src/test/java/org/apache/eagle/alert/cep/TestAlertExecutor.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-public class TestSiddhiEvaluator {
+public class TestAlertExecutor {
 
 	int alertCount = 0;
 
@@ -103,10 +103,10 @@ public class TestSiddhiEvaluator {
 		};
 
 		context.alertExecutor = new AlertExecutor("alertExecutorId", null, 3, 1, alertDao, new String[]{"hdfsAuditLogEventStream"}) {
-			@Override
-			public Map<String, String> getDimensions(String policyId) {
-				return new HashMap<String, String>();
-			}
+//			@Override
+//			public Map<String, String> getDimensions(String policyId) {
+//				return new HashMap<String, String>();
+//			}
 		};
 		context.alertExecutor.prepareConfig(config);
 		context.alertExecutor.init();

--- a/eagle-core/eagle-alert/pom.xml
+++ b/eagle-core/eagle-alert/pom.xml
@@ -33,5 +33,6 @@
 		<module>eagle-alert-base</module>
 		<module>eagle-alert-process</module>
 		<module>eagle-alert-service</module>
+        <module>eagle-executor-state</module>
     </modules>
 </project>

--- a/eagle-core/eagle-data-process/eagle-executor-state/pom.xml
+++ b/eagle-core/eagle-data-process/eagle-executor-state/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ /*
+  ~  * Licensed to the Apache Software Foundation (ASF) under one or more
+  ~  * contributor license agreements.  See the NOTICE file distributed with
+  ~  * this work for additional information regarding copyright ownership.
+  ~  * The ASF licenses this file to You under the Apache License, Version 2.0
+  ~  * (the "License"); you may not use this file except in compliance with
+  ~  * the License.  You may obtain a copy of the License at
+  ~  *
+  ~  *    http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  * Unless required by applicable law or agreed to in writing, software
+  ~  * distributed under the License is distributed on an "AS IS" BASIS,
+  ~  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  * See the License for the specific language governing permissions and
+  ~  * limitations under the License.
+  ~  */
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eagle-alert-parent</artifactId>
+        <groupId>eagle</groupId>
+        <version>0.3.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eagle</groupId>
+    <artifactId>eagle-executor-state</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>eagle</groupId>
+            <artifactId>eagle-entity-base</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>eagle</groupId>
+            <artifactId>eagle-client-base</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.10</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/ExecutorStateConstants.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/ExecutorStateConstants.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state;
+
+/**
+ * constants for policy state management
+ */
+public class ExecutorStateConstants {
+    public final static String POLICY_STATE_SNAPSHOT_SERVICE_ENDPOINT_NAME = "PolicyStateSnapshotService";
+    public final static String POLICY_STATE_DELTA_EVENT_ID_RANGE_SERVICE_ENDPOINT_NAME = "PolicyStateDeltaEventIDRangeService";
+
+    // zookeeper access constants
+    public final static String ZOOKEEPER_RETRY_TIMES_PROPERTY = "eagleProps.executorState.zookeeper.retry.times";
+    public final static int ZOOKEEPER_RETRY_TIMES_DEFAULT = 3;
+    public final static String ZOOKEEPER_RETRY_SLEEP_BETWEEN_RETRIES_PROPERTY = "eagleProps.executorState.zookeeper.sleepMsBetweenRetries";
+    public final static int ZOOKEEPER_RETRY_SLEEP_BETWEEN_RETRIES_DEFAULT = 2000;
+    public final static String ZOOKEEPER_ZKPATH_PROPERTY = "eagleProps.executorState.zookeeper.zkPath";
+    public final static String ZOOKEEPER_ZKPATH_DEFAULT = "/brokers";
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/StateMgmtService.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/StateMgmtService.java
@@ -1,0 +1,88 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state;
+
+import com.typesafe.config.Config;
+import org.apache.eagle.state.base.DeltaEventPersistable;
+import org.apache.eagle.state.base.DeltaEventReplayable;
+import org.apache.eagle.state.deltaevent.DeltaEventDAO;
+import org.apache.eagle.state.deltaevent.DeltaEventKafkaDAOImpl;
+import org.apache.eagle.state.deltaevent.DeltaEventReplayCallback;
+import org.apache.eagle.state.deltaeventoffset.DeltaEventOffsetRangeDAO;
+import org.apache.eagle.state.deltaeventoffset.DeltaEventOffsetRangeEagleServiceDAOImpl;
+import org.apache.eagle.state.base.Snapshotable;
+import org.apache.eagle.state.snapshot.StateSnapshotEagleServiceDAOImpl;
+import org.apache.eagle.state.snapshot.StateSnapshotService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * manage state lifecycle
+ * 1. initialization
+ * 2. periodically take snapshot
+ * 3. persist delta events
+ * 4. restore state including restore snapshot and replay delta events
+ */
+public class StateMgmtService implements DeltaEventPersistable{
+    private static final Logger LOG = LoggerFactory.getLogger(StateMgmtService.class);
+
+    private Object _snapshotLock;
+    private DeltaEventDAO _deltaEventDAO;
+    private DeltaEventOffsetRangeDAO _deltaEventOffsetRangeDAO;
+    private AtomicBoolean _shouldPersistIdRange = new AtomicBoolean(false);
+
+    public StateMgmtService(Config config, final DeltaEventReplayable replayable, Object snapshotLock, Snapshotable snapshotable){
+        _snapshotLock = snapshotLock;
+        _deltaEventDAO = new DeltaEventKafkaDAOImpl(config, snapshotable.getElementId());
+        _deltaEventOffsetRangeDAO = new DeltaEventOffsetRangeEagleServiceDAOImpl(config, snapshotable.getElementId());
+        // recover state from remote storage. state recovery only happens when this bolt is started
+        StateRecoveryService recoverySvc = new StateRecoveryService(config,
+                snapshotable,
+                new StateSnapshotEagleServiceDAOImpl(config),
+                _deltaEventDAO,
+                _deltaEventOffsetRangeDAO,
+                new DeltaEventReplayCallback() {
+                    @Override
+                    public void replay(Object event) {
+                        try {
+                            // invoke worker to replay message
+                            replayable.replay(event);
+                        }catch(Exception ex){
+                            LOG.error("failing replay event " + event);
+                        }
+                    }
+                }
+        );
+        recoverySvc.recover();
+        // make sure snapshot only works after recover is done
+        new StateSnapshotService(config, snapshotable, new StateSnapshotEagleServiceDAOImpl(config), _snapshotLock, _shouldPersistIdRange);
+    }
+
+    public void persist(Object input) throws Exception{
+        long offset = _deltaEventDAO.write(input);
+        if(_shouldPersistIdRange.get()){
+            _deltaEventOffsetRangeDAO.write(offset);
+            // flip this flat
+            _shouldPersistIdRange.set(false);
+        }
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/StateRecoveryService.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/StateRecoveryService.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state;
+
+import com.typesafe.config.Config;
+import org.apache.eagle.state.deltaevent.DeltaEventDAO;
+import org.apache.eagle.state.deltaevent.DeltaEventReplayCallback;
+import org.apache.eagle.state.deltaeventoffset.DeltaEventOffsetRangeDAO;
+import org.apache.eagle.state.entity.DeltaEventOffsetRangeEntity;
+import org.apache.eagle.state.entity.ExecutorStateSnapshotEntity;
+import org.apache.eagle.state.base.Snapshotable;
+import org.apache.eagle.state.snapshot.StateSnapshotDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * State recovery includes two steps
+ * 1. apply latest snapshot
+ * 2. apply all events since latest snapshot
+ */
+public class StateRecoveryService {
+    private final static Logger LOG = LoggerFactory.getLogger(StateRecoveryService.class);
+
+    private Config config;
+    private Snapshotable snapshotable;
+    private StateSnapshotDAO stateSnapshotDAO;
+    private DeltaEventDAO deltaEventDAO;
+    private DeltaEventOffsetRangeDAO deltaEventOffsetRangeDAO;
+    private DeltaEventReplayCallback callback;
+    public StateRecoveryService(Config config,
+                                Snapshotable snapshotable,
+                                StateSnapshotDAO stateSnapshotDAO,
+                                DeltaEventDAO deltaEventDAO,
+                                DeltaEventOffsetRangeDAO deltaEventOffsetRangeDAO,
+                                DeltaEventReplayCallback callback){
+        this.config = config;
+        this.snapshotable = snapshotable;
+        this.stateSnapshotDAO = stateSnapshotDAO;
+        this.deltaEventDAO = deltaEventDAO;
+        this.deltaEventOffsetRangeDAO = deltaEventOffsetRangeDAO;
+        this.callback = callback;
+    }
+
+    public void recover(){
+        String site = config.getString("eagleProps.site");
+        String applicationId = config.getString("eagleProps.dataSource");
+        String elementId = snapshotable.getElementId();
+        LOG.info("start recovering state for " + applicationId + "/" + elementId);
+        LOG.info("step 1 of 2, start restoring snapshot for " + applicationId + "/" + elementId);
+        // fetch state from DAO
+        ExecutorStateSnapshotEntity snapshotEntity = null;
+        try{
+            snapshotEntity = stateSnapshotDAO.findLatestState(site, applicationId, elementId);
+        }catch(Exception ex){
+            LOG.error("error finding latest state snapshot, but continue to run", ex);
+            return;
+        }
+        byte[] snapshot = null;
+        if(snapshotEntity != null) {
+            snapshot = snapshotEntity.getState();
+        }else{
+            LOG.warn("snapshot is empty, continue to run");
+        }
+        snapshotable.restoreState(snapshot);
+        LOG.info("step 1 of 2, end restoring snapshot for " + applicationId + "/" + elementId);
+        // apply delta devents
+        LOG.info("step 2 of 2, start replaying delta events for " + applicationId + "/" + elementId);
+        // 1. get starting id
+        DeltaEventOffsetRangeEntity idRangeEntity = null;
+        try{
+            idRangeEntity = deltaEventOffsetRangeDAO.findLatestIdRange();
+        }catch(Exception ex){
+            LOG.error("fail reading deltaEventIdRange, use max value");
+        }
+        if(idRangeEntity == null){
+            LOG.warn("delta event is empty, so ignore event replay");
+        }else if(idRangeEntity.getTimestamp() < snapshotEntity.getTimestamp()){
+            LOG.warn("snapshot is newer than last recorded delta event, " + snapshotEntity.getTimestamp() + ">" + idRangeEntity.getTimestamp() + ", so ignore event replay");
+        }else {
+            long startingOffset = idRangeEntity.getStartingOffset();
+            LOG.info("recorded delta event startingOffset " + startingOffset);
+            // 2. get max offset right now
+            try {
+                deltaEventDAO.load(startingOffset, callback);
+            } catch (Exception ex) {
+                LOG.error("fail loading deltaEvent starting offset, but continue to run", ex);
+            }
+        }
+        LOG.info("step 2 of 2, end replaying delta events for " + applicationId + "/" + elementId);
+        LOG.info("end recovering state for " + applicationId + "/" + elementId);
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/DeltaEventPersistable.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/DeltaEventPersistable.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.base;
+
+/**
+ * interface for persisting delta events since last snapshot
+ */
+public interface DeltaEventPersistable {
+    void persist(Object event) throws Exception;
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/DeltaEventReplayable.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/DeltaEventReplayable.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.base;
+
+/**
+ * interface for replaying delta event
+ */
+public interface DeltaEventReplayable {
+    void replay(Object event);
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/ExecutorStateMgmtEntityRepo.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/ExecutorStateMgmtEntityRepo.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.base;
+
+import org.apache.eagle.state.entity.DeltaEventOffsetRangeEntity;
+import org.apache.eagle.state.entity.ExecutorStateSnapshotEntity;
+import org.apache.eagle.log.entity.repo.EntityRepository;
+
+/**
+ * repository to register executor state related entities
+ */
+public class ExecutorStateMgmtEntityRepo extends EntityRepository {
+    public ExecutorStateMgmtEntityRepo(){
+        entitySet.add(ExecutorStateSnapshotEntity.class);
+        entitySet.add(DeltaEventOffsetRangeEntity.class);
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/Snapshotable.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/base/Snapshotable.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.base;
+
+/**
+ * interface for returning current state and recovering from state provided outside
+ * This is to align with org.wso2.siddhi.core.util.snapshot.Snapshotable
+ */
+public interface Snapshotable {
+    public byte[] currentState();
+    public void restoreState(byte[] state);
+
+    /**
+     * unique Id to identity this Snapshotable object. When restoring state, it is used for check if the element still exists
+     * @return
+     */
+    public String getElementId();
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventDAO.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventDAO.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import java.io.Closeable;
+
+/**
+ * interface for persisting delta events which can be used for replaying events based on latest snapshot while doing failover
+ */
+public interface DeltaEventDAO extends Closeable{
+    /**
+     * writeState event and return id which represents that event,
+     * the return id will be used for replaying
+     * @return
+     * @throws Exception
+     */
+    long write(Object event) throws Exception;
+
+    void load(long startOffset, DeltaEventReplayCallback callback) throws Exception;
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKafkaDAOImpl.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKafkaDAOImpl.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import com.typesafe.config.Config;
+import kafka.javaapi.TopicMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+/**
+ * writeState delta events to kafka
+ * 1. topic should be a format like executor_state_${applicationId}
+ * 2. delta event should be keyed by executorId and partitionId
+ *
+ * need consider close KafkaProducer and release I/O resource used by KafkaProducer
+ */
+public class DeltaEventKafkaDAOImpl implements DeltaEventDAO {
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaEventKafkaDAOImpl.class);
+    private String topic;
+    private KafkaProducer producer;
+    private int partitionNum;
+    private String site;
+    private String applicationId;
+    private String elementId;
+    private KafkaReadWithOffsetRange offsetReader;
+
+    public DeltaEventKafkaDAOImpl(Config config, String elementId){
+        // create KafkaProducer
+        this.elementId = elementId;
+        this.site = config.getString("eagleProps.site");
+        this.applicationId = config.getString("eagleProps.dataSource");
+        String topicBase = config.getString("eagleProps.executorState.topicBase");
+        topic = topicBase + "_" + site + "_" + applicationId;
+        Map producerConfigs = config.getObject("eagleProps.executorState.deltaEventKafkaProducerConfig").unwrapped();
+        producer = new KafkaProducer(producerConfigs);
+
+        // fetch number of partitions
+        List<String> brokerList = Arrays.asList(config.getString("eagleProps.executorState.brokerList").split(","));
+        int brokerPort = config.getInt("eagleProps.executorState.brokerPort");
+        TopicMetadata topicMetadata = KafkaMetadataUtils.metadataForTopic(brokerList, brokerPort, "eagleExecutorState_leaderLookup", topic);
+        int numPartitions = topicMetadata.partitionsMetadata().size();
+        LOG.info("topic: " + topic + ", total number of partitions: " + numPartitions);
+        DeltaEventKey key = new DeltaEventKey();
+        key.setSite(site);
+        key.setElementId(elementId);
+        key.setApplicationId(applicationId);
+        partitionNum = Math.abs(key.hashCode()) % numPartitions;
+
+        // initialize kafka reader
+        String deserializerCls = config.getString("eagleProps.executorState.deltaEventKafkaConsumerConfig.valueDeserializer");
+        try {
+            offsetReader = new KafkaReadWithOffsetRange(brokerList,
+                    brokerPort,
+                    topic,
+                    partitionNum,
+                    (Deserializer)Class.forName(deserializerCls).newInstance()
+            );
+        }catch(Exception ex){
+            LOG.error("fail creating kafka reader", ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public long write(Object event) throws Exception {
+        DeltaEventKey key = new DeltaEventKey();
+        key.setSite(site);
+        key.setElementId(elementId);
+        key.setApplicationId(applicationId);
+        DeltaEventValue value = new DeltaEventValue();
+        value.setElementId(elementId);
+        value.setEvent(event);
+        ProducerRecord<DeltaEventKey, Object> record = new ProducerRecord<DeltaEventKey, Object>(topic, partitionNum, key, value);
+        Future<RecordMetadata> future = producer.send(record);
+        RecordMetadata recordMetadata = future.get();
+        return recordMetadata.offset();
+    }
+
+    @Override
+    public void load(long startOffset, DeltaEventReplayCallback callback) throws Exception{
+        offsetReader.readUntilMaxOffset(startOffset, callback);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.producer.close();
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKey.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKey.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.io.Serializable;
+
+/**
+ * a combination of fields which consists of the key a delta event
+ */
+public class DeltaEventKey implements Serializable {
+    private String site;
+    private String applicationId;
+    private String elementId;
+
+    public String getSite() {
+        return site;
+    }
+
+    public void setSite(String site) {
+        this.site = site;
+    }
+
+    public String getElementId() {
+        return elementId;
+    }
+
+    public void setElementId(String elementId) {
+        this.elementId = elementId;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    @Override
+    public int hashCode(){
+        return new HashCodeBuilder().append(site).append(applicationId).append(elementId).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object that){
+        if(this == that)
+            return true;
+        if(that == null && !(that instanceof DeltaEventKey))
+            return false;
+        DeltaEventKey thatKey = (DeltaEventKey)that;
+        if(thatKey.applicationId.equals(this.applicationId) &&
+                thatKey.elementId.equals(this.elementId) &&
+                thatKey.site.equals(this.site))
+            return true;
+        return false;
+    }
+
+    /**
+     * serialize this object into output stream
+     * @param s
+     */
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException{
+        s.writeUTF(site);
+        s.writeUTF(applicationId);
+        s.writeUTF(elementId);
+    }
+
+    private void readObject(final java.io.ObjectInputStream s) throws java.io.IOException{
+        site = s.readUTF();
+        applicationId = s.readUTF();
+        elementId = s.readUTF();
+    }
+
+    @Override
+    public String toString() {
+        return "DeltaEventKey{" +
+                "site='" + site + '\'' +
+                ", applicationId='" + applicationId + '\'' +
+                ", elementId='" + elementId + '\'' +
+                '}';
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKeyDeserializer.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKeyDeserializer.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Map;
+
+/**
+ * delta event key serializer
+ */
+public class DeltaEventKeyDeserializer implements Deserializer<DeltaEventKey> {
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaEventKeyDeserializer.class);
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public DeltaEventKey deserialize(String topic, byte[] data) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(data);
+        ObjectInput in = null;
+        DeltaEventKey ret = null;
+        try{
+            in = new ObjectInputStream(bis);
+            ret = (DeltaEventKey)in.readObject();
+        }catch(Exception ex){
+            LOG.error("error serializing object", ex);
+        }finally{
+            try {
+                bis.close();
+                in.close();
+            }catch(Exception ex){}
+        }
+        return ret;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKeySerializer.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventKeySerializer.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+/**
+ * delta event key serializer
+ */
+public class DeltaEventKeySerializer implements Serializer<DeltaEventKey> {
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaEventKeySerializer.class);
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, DeltaEventKey data) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutput out = null;
+        try{
+            out = new ObjectOutputStream(bos);
+            out.writeObject(data);
+        }catch(Exception ex){
+            LOG.error("error serializing object", ex);
+        }finally{
+            try {
+                bos.close();
+                out.close();
+            }catch(Exception ex){}
+        }
+        return bos.toByteArray();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventReplayCallback.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventReplayCallback.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+/**
+ * interface for replaying delta events
+ */
+public interface DeltaEventReplayCallback {
+    void replay(Object event);
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventValue.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventValue.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * wrapper class for delta event object which is provided by caller
+ */
+public class DeltaEventValue implements Serializable {
+    private static final long serialVersionUID = -6947238996278788982L;
+    private String elementId;
+    private Object event;
+
+    public String getElementId() {
+        return elementId;
+    }
+
+    public void setElementId(String elementId) {
+        this.elementId = elementId;
+    }
+
+    public Object getEvent() {
+        return event;
+    }
+
+    public void setEvent(Object event) {
+        this.event = event;
+    }
+
+    public void writeObject(ObjectOutputStream s) throws IOException {
+        s.writeUTF(elementId);
+        s.writeObject(event);
+    }
+    public void readObject(ObjectInputStream s) throws Exception {
+        elementId = s.readUTF();
+        event = s.readObject();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DeltaEventValue that = (DeltaEventValue) o;
+
+        if (!elementId.equals(that.elementId)) return false;
+        return event.equals(that.event);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = elementId.hashCode();
+        result = 31 * result + event.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DeltaEventValue{" +
+                "elementId='" + elementId + '\'' +
+                ", event=" + event +
+                '}';
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventValueDeserializer.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventValueDeserializer.java
@@ -1,0 +1,64 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.util.Map;
+
+/**
+ * delta event key serializer
+ */
+public class DeltaEventValueDeserializer implements Deserializer<DeltaEventValue> {
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaEventValueDeserializer.class);
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public DeltaEventValue deserialize(String topic, byte[] data) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(data);
+        ObjectInput in = null;
+        DeltaEventValue ret = null;
+        try{
+            in = new ObjectInputStream(bis);
+            ret = (DeltaEventValue)in.readObject();
+        }catch(Exception ex){
+            LOG.error("error deserializing object, ignore this event", ex);
+            throw new RuntimeException(ex);
+        }finally{
+            try {
+                bis.close();
+                in.close();
+            }catch(Exception ex){}
+        }
+        return ret;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventValueSerializer.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/DeltaEventValueSerializer.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+/**
+ * serialize delta event value to bytes
+ */
+public class DeltaEventValueSerializer implements Serializer<DeltaEventValue> {
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaEventValueSerializer.class);
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, DeltaEventValue data) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutput out = null;
+        try{
+            out = new ObjectOutputStream(bos);
+            out.writeObject(data);
+        }catch(Exception ex){
+            LOG.error("error serializing object", ex);
+        }finally{
+            try {
+                bos.close();
+                out.close();
+            }catch(Exception ex){}
+        }
+        return bos.toByteArray();
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/KafkaMetadataUtils.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/KafkaMetadataUtils.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import kafka.javaapi.PartitionMetadata;
+import kafka.javaapi.TopicMetadata;
+import kafka.javaapi.TopicMetadataRequest;
+import kafka.javaapi.consumer.SimpleConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Some utility methods to get Kafka related information including
+ * 1. metadata for one topic
+ * 2. metadata for one partition of a topic
+ */
+public class KafkaMetadataUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaMetadataUtils.class);
+
+    public static TopicMetadata metadataForTopic(List<String> brokers, int port, String clientId, String topic){
+        for (String seed : brokers) {
+            SimpleConsumer consumer = null;
+            try {
+                consumer = new SimpleConsumer(seed, port, 100000, 64 * 1024, clientId);
+                List<String> topics = Collections.singletonList(topic);
+                TopicMetadataRequest req = new TopicMetadataRequest(topics);
+                kafka.javaapi.TopicMetadataResponse resp = consumer.send(req);
+                List<TopicMetadata> metaData = resp.topicsMetadata();
+                return metaData.get(0);
+            } catch (Exception e) {
+                LOG.error("Error communicating with Broker [" + seed + "] to find Leader for [" + topic + "] Reason: " + e);
+            } finally {
+                if (consumer != null) consumer.close();
+            }
+        }
+        return null;
+    }
+
+    public static PartitionMetadata metadataForPartition(List<String> brokers, int port, String clientId, String topic, int partition){
+        PartitionMetadata returnMetaData = null;
+        TopicMetadata topicMetadata = metadataForTopic(brokers, port, clientId, topic);
+        if(topicMetadata == null)
+            return null;
+        for (kafka.javaapi.PartitionMetadata part : topicMetadata.partitionsMetadata()) {
+            if (part.partitionId() == partition) {
+                returnMetaData = part;
+                break;
+            }
+        }
+        return returnMetaData;
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/KafkaReadWithOffsetRange.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaevent/KafkaReadWithOffsetRange.java
@@ -1,0 +1,187 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import kafka.api.FetchRequest;
+import kafka.api.FetchRequestBuilder;
+import kafka.api.PartitionOffsetRequestInfo;
+import kafka.common.ErrorMapping;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.*;
+import kafka.javaapi.consumer.SimpleConsumer;
+import kafka.message.MessageAndOffset;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+
+/**
+ * read kafka message from a specified start offset to current
+ * does not support multiple threads
+ */
+public class KafkaReadWithOffsetRange {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaReadWithOffsetRange.class);
+
+    private List<String> m_replicaBrokers = new ArrayList<String>();
+    private List<String> seedBrokers;
+    private int port;
+    private String topic;
+    private int partition;
+    private Deserializer msgDeserializer;
+
+    public KafkaReadWithOffsetRange(List<String> seedBrokers, int port, String topic, int partition, Deserializer msgDeserializer){
+        this.seedBrokers = seedBrokers;
+        this.port = port;
+        this.topic = topic;
+        this.partition = partition;
+        this.msgDeserializer = msgDeserializer;
+    }
+    public void readUntilMaxOffset(long startOffset, DeltaEventReplayCallback callback) throws Exception{
+        LOG.info("reading kafka message from offset " + startOffset + " for topic " + topic + ", partition " + partition);
+        String clientName = "eagleExecutorState_" + topic + "_" + partition;
+        PartitionMetadata metadata = findLeader(seedBrokers);
+        if (metadata == null) {
+            LOG.error("fail finding metadata for Topic and Partition: " + topic + "/" + partition);
+            return;
+        }
+        if (metadata.leader() == null) {
+            LOG.error("fail finding metadata for Topic and Partition: " + topic + "/" + partition);
+            return;
+        }
+        String leadBroker = metadata.leader().host();
+        SimpleConsumer consumer = new SimpleConsumer(leadBroker, port, 100000, 64 * 1024, clientName);
+        long maxOffset = getLatestOffset(consumer, clientName);
+        internalRead(consumer, leadBroker, clientName, callback, startOffset, maxOffset);
+    }
+
+    private void internalRead(SimpleConsumer consumer, String leadBroker, String clientName, DeltaEventReplayCallback callback, long startOffset, long maxOffset) throws Exception{
+        long totalReplayed = 0L;
+        long failedReplayed = 0L;
+        int numErrors = 0;
+        boolean finished = false;
+        while (!finished) {
+            // in some case, lead change will trigger consumer close and we need recreate consumer
+            if(consumer == null){
+                consumer = new SimpleConsumer(leadBroker, port, 100000, 64 * 1024, clientName);
+            }
+            FetchRequest req = new FetchRequestBuilder()
+                    .clientId(clientName)
+                    .addFetch(topic, partition, startOffset, 100000)
+                    .build();
+            FetchResponse fetchResponse = consumer.fetch(req);
+
+            if (fetchResponse.hasError()) {
+                numErrors++;
+                short code = fetchResponse.errorCode(topic, partition);
+                LOG.error("Error fetching data from the Broker:" + leadBroker + " Reason: " + code);
+                if (numErrors > 5) break;
+                if (code == ErrorMapping.OffsetOutOfRangeCode())  {
+                    String errMsg = "try to read offset which is out of range";
+                    LOG.error(errMsg);
+                    throw new RuntimeException(errMsg);
+                }
+                consumer.close();
+                consumer = null;
+                leadBroker = findNewLeader(leadBroker);
+                continue;
+            }
+            numErrors = 0;
+
+            for (MessageAndOffset messageAndOffset : fetchResponse.messageSet(topic, partition)) {
+                long currentOffset = messageAndOffset.offset();
+                if (currentOffset < startOffset) {
+                    LOG.info("Found an old offset: " + currentOffset + " Expecting: " + startOffset);
+                    continue;
+                }
+                ByteBuffer payload = messageAndOffset.message().payload();
+                byte[] bytes = new byte[payload.limit()];
+                payload.get(bytes);
+                DeltaEventValue event = null;
+                try {
+                    event = (DeltaEventValue)msgDeserializer.deserialize(topic, bytes);
+                }catch(Exception ex){
+                    failedReplayed++;
+                    LOG.error("deserialization error, ignore this event");
+                }
+                totalReplayed++;
+                if(event != null) {
+                    callback.replay(event.getEvent());
+                }
+                if(currentOffset >= maxOffset-1){
+                    finished = true;
+                    break;
+                }
+            }
+        }
+        LOG.info("total replayed events " + totalReplayed, ", failedReplayed " + failedReplayed);
+        if (consumer != null) consumer.close();
+    }
+
+    private PartitionMetadata findLeader(List<String> replicaBrokers) {
+        PartitionMetadata returnMetaData = KafkaMetadataUtils.metadataForPartition(replicaBrokers, port, "eagleExecutorState_leaderLookup", topic, partition);
+        if (returnMetaData != null) {
+            m_replicaBrokers.clear();
+            for (kafka.cluster.Broker replica : returnMetaData.replicas()) {
+                m_replicaBrokers.add(replica.host());
+            }
+        }
+        return returnMetaData;
+    }
+
+    private String findNewLeader(String oldLeader) throws Exception {
+        for (int i = 0; i < 3; i++) {
+            boolean goToSleep = false;
+            PartitionMetadata metadata = findLeader(m_replicaBrokers);
+            if (metadata == null) {
+                goToSleep = true;
+            } else if (metadata.leader() == null) {
+                goToSleep = true;
+            } else if (oldLeader.equalsIgnoreCase(metadata.leader().host()) && i == 0) {
+                // first time through if the leader hasn't changed give ZooKeeper a second to recover
+                // second time, assume the broker did recover before failover, or it was a non-Broker issue
+                goToSleep = true;
+            } else {
+                return metadata.leader().host();
+            }
+            if (goToSleep) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+        throw new Exception("Unable to find new leader after Broker failure. Exiting");
+    }
+
+    public long getLatestOffset(SimpleConsumer consumer, String clientId) {
+        TopicAndPartition topicAndPartition = new TopicAndPartition(topic, partition);
+        Map<TopicAndPartition, PartitionOffsetRequestInfo> requestInfo = new HashMap<>();
+        requestInfo.put(topicAndPartition, new PartitionOffsetRequestInfo(kafka.api.OffsetRequest.LatestTime(), 1));
+        kafka.javaapi.OffsetRequest request = new kafka.javaapi.OffsetRequest(requestInfo, kafka.api.OffsetRequest.CurrentVersion(), clientId);
+        OffsetResponse response = consumer.getOffsetsBefore(request);
+        if (response.hasError()) {
+            throw new RuntimeException("Error fetching data offset from the broker. Reason: " + response.errorCode(topic, partition) );
+        }
+        long[] offsets = response.offsets(topic, partition);
+        return offsets[0];
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaeventoffset/DeltaEventOffsetRangeDAO.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaeventoffset/DeltaEventOffsetRangeDAO.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaeventoffset;
+
+import org.apache.eagle.state.entity.DeltaEventOffsetRangeEntity;
+
+import java.io.IOException;
+
+/**
+ * persist/read earliest delta event id since latest snapshot
+ */
+public interface DeltaEventOffsetRangeDAO {
+    void write(long id) throws IOException;
+    DeltaEventOffsetRangeEntity findLatestIdRange() throws IOException;
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaeventoffset/DeltaEventOffsetRangeEagleServiceDAOImpl.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/deltaeventoffset/DeltaEventOffsetRangeEagleServiceDAOImpl.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaeventoffset;
+
+import com.typesafe.config.Config;
+import org.apache.eagle.state.entity.DeltaEventOffsetRangeEntity;
+import org.apache.eagle.state.ExecutorStateConstants;
+import org.apache.eagle.log.entity.GenericServiceAPIResponseEntity;
+import org.apache.eagle.service.client.EagleServiceConnector;
+import org.apache.eagle.service.client.IEagleServiceClient;
+import org.apache.eagle.service.client.impl.EagleServiceClientImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * DAO methods backed by eagle service
+ */
+public class DeltaEventOffsetRangeEagleServiceDAOImpl implements DeltaEventOffsetRangeDAO {
+    private final static Logger LOG = LoggerFactory.getLogger(DeltaEventOffsetRangeEagleServiceDAOImpl.class);
+    private Config config;
+    private String site;
+    private String applicationId;
+    private String elementId;
+
+    public DeltaEventOffsetRangeEagleServiceDAOImpl(Config config, String elementId){
+        this.config = config;
+        this.site = config.getString("eagleProps.site");
+        this.applicationId = config.getString("eagleProps.dataSource");
+        this.elementId = elementId;
+    }
+
+    @Override
+    public void write(long id) throws IOException{
+        LOG.info(applicationId + "/" + elementId + ", write first offset after latest snapshot " + id);
+        DeltaEventOffsetRangeEntity entity = new DeltaEventOffsetRangeEntity();
+        entity.setTags(new HashMap<String, String>(){{
+            put("site", site);
+            put("applicationId", applicationId);
+            put("executorId", elementId);
+        }});
+        entity.setTimestamp(new Date().getTime());
+        entity.setStartingOffset(id);
+        IEagleServiceClient client = new EagleServiceClientImpl(new EagleServiceConnector(config));
+        GenericServiceAPIResponseEntity response = null;
+        try{
+            response = client.create(Arrays.asList(entity));
+        }catch(Exception ex){
+            LOG.error("fail creating entity", ex);
+            throw new IOException(ex);
+        }
+        if(!response.isSuccess()){
+            LOG.error("fail creating entity with exception " + response.getException());
+            throw new IOException(response.getException());
+        }
+        client.close();
+        LOG.info("end write offset: " + applicationId + "/" + elementId);
+    }
+
+    @Override
+    public DeltaEventOffsetRangeEntity findLatestIdRange() throws IOException {
+        IEagleServiceClient client = new EagleServiceClientImpl(new EagleServiceConnector(config));
+        String query = ExecutorStateConstants.POLICY_STATE_DELTA_EVENT_ID_RANGE_SERVICE_ENDPOINT_NAME + "[@applicationId=\"" + applicationId +
+                "\" AND @site=\"" + site +
+                "\" AND @executorId=\"" + elementId +
+                "\"]{*}";
+        GenericServiceAPIResponseEntity<DeltaEventOffsetRangeEntity> response = null;
+        try {
+            response = client.search()
+                    .startTime(0)
+                    .endTime(new Date().getTime())
+                    .pageSize(1)
+                    .query(query)
+                    .send();
+        }catch(Exception ex){
+            LOG.error("error querying delta event Id range" + ex);
+            throw new IOException(ex);
+        }
+        client.close();
+        if (response.getException() != null) {
+            throw new IOException("Got an exception when query eagle service: " + response.getException());
+        }
+        List<DeltaEventOffsetRangeEntity> entities = response.getObj();
+        if(entities.size() >= 1){
+            return entities.get(0);
+        }
+        return null;
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/entity/DeltaEventOffsetRangeEntity.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/entity/DeltaEventOffsetRangeEntity.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.entity;
+
+import org.apache.eagle.state.ExecutorStateConstants;
+import org.apache.eagle.log.base.taggedlog.TaggedLogAPIEntity;
+import org.apache.eagle.log.entity.meta.*;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * The starting point for the delta events since the lastest snapshot
+ * Eagle uses Kafka as default storage for storing delta events, and the events can be partitioned by executorId
+ * When events replay, each executor should filter the messages which belong to itself only
+ */
+@JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+@Table("deltaEventIdRange")
+@ColumnFamily("f")
+@Prefix("deltaEventIdRange")
+@Service(ExecutorStateConstants.POLICY_STATE_DELTA_EVENT_ID_RANGE_SERVICE_ENDPOINT_NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@TimeSeries(true)
+@Tags({"site", "dataSource", "executorId"})
+public class DeltaEventOffsetRangeEntity extends TaggedLogAPIEntity {
+    @Column("a")
+    private Long startingOffset;
+
+    public Long getStartingOffset(){
+        return startingOffset;
+    }
+
+    public void setStartingOffset(Long startingOffset){
+        this.startingOffset = startingOffset;
+        valueChanged("startingOffset");
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/entity/ExecutorStateSnapshotEntity.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/entity/ExecutorStateSnapshotEntity.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.entity;
+
+import org.apache.eagle.state.ExecutorStateConstants;
+import org.apache.eagle.log.base.taggedlog.TaggedLogAPIEntity;
+import org.apache.eagle.log.entity.meta.*;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * policy state snapshot is stored in eagle service as an entity
+ * This can be extended to writeState state for any processing element in the topology
+ */
+@JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+@Table("policyStateSnapshot")
+@ColumnFamily("f")
+@Prefix("policyStateSnapshot")
+@Service(ExecutorStateConstants.POLICY_STATE_SNAPSHOT_SERVICE_ENDPOINT_NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@TimeSeries(true)
+@Tags({"site", "applicationId", "executorId"})
+public class ExecutorStateSnapshotEntity extends TaggedLogAPIEntity {
+    @Column("a")
+    private byte[] state;
+
+    public byte[] getState(){
+        return this.state;
+    }
+    public void setState(byte[] state){
+        this.state = state;
+        valueChanged("state");
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/ByteSerializer.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/ByteSerializer.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.snapshot;
+
+import org.apache.log4j.Logger;
+
+import java.io.*;
+
+/**
+ * serialization/deserialization of objects
+ */
+public class ByteSerializer {
+    private static final Logger log = Logger.getLogger(ByteSerializer.class);
+
+    private ByteSerializer() {
+    }
+
+    public static byte[] OToB(Object obj) {
+        long start = System.currentTimeMillis();
+        byte[] out = null;
+        if (obj != null) {
+            try {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos);
+                oos.writeObject(obj);
+                out = baos.toByteArray();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+        long end = System.currentTimeMillis();
+        if (log.isDebugEnabled()) {
+            log.debug("Encoded in :" + (end - start) + " msec");
+        }
+        return out;
+    }
+
+    public static Object BToO(byte[] bytes) {
+        long start = System.currentTimeMillis();
+        Object out = null;
+        if (bytes != null) {
+            try {
+                ByteArrayInputStream bios = new ByteArrayInputStream(bytes);
+                ObjectInputStream ois = new ObjectInputStream(bios);
+                out = ois.readObject();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+        long end = System.currentTimeMillis();
+        if (log.isDebugEnabled()) {
+            log.debug("Decoded in :" + (end - start) + " msec");
+        }
+        return out;
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/StateSnapshotDAO.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/StateSnapshotDAO.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.snapshot;
+
+import org.apache.eagle.state.entity.ExecutorStateSnapshotEntity;
+
+import java.io.IOException;
+
+/**
+ * interface for common DAO operations
+ */
+public interface StateSnapshotDAO {
+    void writeState(String site, String applicationId, String executorId, byte[] state) throws IOException;
+    ExecutorStateSnapshotEntity findLatestState(String site, String applicationId, String executorId) throws IOException;
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/StateSnapshotEagleServiceDAOImpl.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/StateSnapshotEagleServiceDAOImpl.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.snapshot;
+
+import com.typesafe.config.Config;
+import org.apache.eagle.state.ExecutorStateConstants;
+import org.apache.eagle.state.entity.ExecutorStateSnapshotEntity;
+import org.apache.eagle.log.entity.GenericServiceAPIResponseEntity;
+import org.apache.eagle.service.client.EagleServiceConnector;
+import org.apache.eagle.service.client.IEagleServiceClient;
+import org.apache.eagle.service.client.impl.EagleServiceClientImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * DAO methods backed by eagle service
+ */
+public class StateSnapshotEagleServiceDAOImpl implements StateSnapshotDAO{
+    private final static Logger LOG = LoggerFactory.getLogger(StateSnapshotEagleServiceDAOImpl.class);
+
+    private Config config;
+    public StateSnapshotEagleServiceDAOImpl(Config config){
+        this.config = config;
+    }
+    @Override
+    public void writeState(final String site, final String applicationId, final String executorId, byte[] state) throws IOException{
+        LOG.info("start writing state snapshot: " + applicationId + "/" + executorId + ", with state byte size " + state.length);
+        ExecutorStateSnapshotEntity entity = new ExecutorStateSnapshotEntity();
+        entity.setTags(new HashMap<String, String>(){{
+            put("site", site);
+            put("applicationId", applicationId);
+            put("executorId", executorId);
+        }});
+        entity.setTimestamp(new Date().getTime());
+        entity.setState(state);
+        IEagleServiceClient client = new EagleServiceClientImpl(new EagleServiceConnector(config));
+        GenericServiceAPIResponseEntity response = null;
+        try{
+            response = client.create(Arrays.asList(entity));
+        }catch(Exception ex){
+            LOG.error("fail creating entity", ex);
+            throw new IOException(ex);
+        }
+        if(!response.isSuccess()){
+            LOG.error("fail creating entity with exception " + response.getException());
+            throw new IOException(response.getException());
+        }
+        client.close();
+        LOG.info("end writing state snapshot: " + applicationId + "/" + executorId);
+    }
+
+    @Override
+    public ExecutorStateSnapshotEntity findLatestState(String site, String applicationId, String executorId) throws IOException{
+        IEagleServiceClient client = new EagleServiceClientImpl(new EagleServiceConnector(config));
+        String query = ExecutorStateConstants.POLICY_STATE_SNAPSHOT_SERVICE_ENDPOINT_NAME + "[@applicationId=\"" + applicationId +
+                "\" AND @site=\"" + site +
+                "\" AND @executorId=\"" + executorId +
+                "\"]{*}";
+        GenericServiceAPIResponseEntity<ExecutorStateSnapshotEntity> response = null;
+        try {
+            response = client.search()
+                    .startTime(0)
+                    .endTime(new Date().getTime())
+                    .pageSize(1)
+                    .query(query)
+                    .send();
+        }catch(Exception ex){
+            LOG.error("error querying state snapshot" + ex);
+            throw new IOException(ex);
+        }
+        client.close();
+        if (response.getException() != null) {
+            throw new IOException("Got an exception when query eagle service: " + response.getException());
+        }
+        List<ExecutorStateSnapshotEntity> entities = response.getObj();
+        if(entities.size() >= 1){
+            return entities.get(0);
+        }
+        return null;
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/StateSnapshotService.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/java/org/apache/eagle/state/snapshot/StateSnapshotService.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.snapshot;
+
+import com.typesafe.config.Config;
+import org.apache.eagle.state.base.Snapshotable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * service for periodically taking snapshots and persisting snapshots to durable storage
+ */
+public class StateSnapshotService {
+    private final static Logger LOG = LoggerFactory.getLogger(StateSnapshotService.class);
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    public StateSnapshotService(Config config, final Snapshotable snapshotable, final StateSnapshotDAO stateDAO, final Object snapshotLock, final AtomicBoolean shouldPersist){
+        // start up daemon thread to periodically take snapshot
+        long interval = config.getLong("eagleProps.executorState.snapshotIntervalMS");
+        final String site = config.getString("eagleProps.site");
+        final String applicationId = config.getString("eagleProps.dataSource");
+        final String executorId = snapshotable.getElementId();
+        scheduler.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                LOG.info("start taking state snapshot for " + applicationId + "/" + executorId);
+                synchronized (snapshotLock) {
+                    try {
+                        byte[] state = snapshotable.currentState();
+                        stateDAO.writeState(site, applicationId, executorId, state);
+                        shouldPersist.set(true);
+                    }catch(Exception ex){
+                        LOG.error("fail writing state, but continue to run", ex);
+                    }
+                }
+                LOG.info("end taking state snapshot for " + applicationId + "/" + executorId);
+            }
+        }, 0L, interval, TimeUnit.MILLISECONDS);
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/main/resources/log4j.properties
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/main/resources/log4j.properties
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.rootLogger=INFO, stdout, DRFA
+
+eagle.log.dir=./logs
+eagle.log.file=eagle.log
+
+
+#log4j.logger.org.apache.eagle.security.auditlog.IPZoneDataJoinExecutor=DEBUG
+#log4j.logger.org.apache.eagle.security.auditlog.FileSensitivityDataJoinExecutor=DEBUG
+log4j.logger.org.apache.eagle.security.auditlog.HdfsUserCommandReassembler=DEBUG
+#log4j.logger.org.apache.eagle.executor.AlertExecutor=DEBUG
+# standard output
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %p [%t] %c{2}[%L]: %m%n
+
+# Daily Rolling File Appender
+log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.DRFA.File=${eagle.log.dir}/${eagle.log.file}
+log4j.appender.DRFA.DatePattern=yyyy-MM-dd
+## 30-day backup
+# log4j.appender.DRFA.MaxBackupIndex=30
+log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
+
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p [%t] %c{2}[%L]: %m%n

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestDeltaEventIdRangeEagleServiceDAOImpl.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestDeltaEventIdRangeEagleServiceDAOImpl.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import junit.framework.Assert;
+import org.apache.eagle.state.deltaeventoffset.DeltaEventOffsetRangeDAO;
+import org.apache.eagle.state.deltaeventoffset.DeltaEventOffsetRangeEagleServiceDAOImpl;
+import org.junit.Test;
+
+/**
+ * test read/write deltaeventIdRange
+ */
+public class TestDeltaEventIdRangeEagleServiceDAOImpl {
+    @Test
+    public void testReadWrite() throws Exception{
+        System.setProperty("eagleProps.eagleService.host", "localhost");
+        System.setProperty("eagleProps.eagleService.port", "38080");
+        System.setProperty("eagleProps.eagleService.username", "admin");
+        System.setProperty("eagleProps.eagleService.password", "secret");
+        Config config = ConfigFactory.load();
+        DeltaEventOffsetRangeDAO dao = new DeltaEventOffsetRangeEagleServiceDAOImpl(config, "executorId1");
+        long offset = 101;
+        dao.write(offset);
+        long retOffset = dao.findLatestIdRange().getStartingOffset();
+        Assert.assertEquals(offset, retOffset);
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestDeltaEventKafkaDAOImpl.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestDeltaEventKafkaDAOImpl.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+/**
+ * test kafka implementation of delta event DAO
+ */
+public class TestDeltaEventKafkaDAOImpl {
+    @Test
+    public void testWriteRead() throws Exception{
+        Config config = ConfigFactory.load();
+        String elementId = "executorId1_1";
+        DeltaEventDAO deltaEventDAO = new DeltaEventKafkaDAOImpl(config, elementId);
+        long startOffset = deltaEventDAO.write("abcefg1");
+        deltaEventDAO.write("abcefg2");
+        deltaEventDAO.write("abcefg3");
+        deltaEventDAO.write("abcefg4");
+        deltaEventDAO.load(startOffset, new DeltaEventReplayCallback() {
+            @Override
+            public void replay(Object event) {
+                System.out.println(event);
+            }
+        });
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestGetNumPartitions.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestGetNumPartitions.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import kafka.admin.AdminUtils;
+import kafka.api.TopicMetadata;
+import org.I0Itec.zkclient.ZkClient;
+import scala.collection.JavaConversions;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * get number of partitions for a topic
+ */
+public class TestGetNumPartitions {
+    public static void main(String[] args) throws Exception{
+        ZkClient zkClient = new ZkClient("localhost:2181");
+        try {
+            AdminUtils.createTopic(zkClient, "testTopic", 3, 1, new Properties());
+        }catch(Exception ex){
+            // continue to run
+        }
+        TopicMetadata metadata = AdminUtils.fetchTopicMetadataFromZk("testTopic", zkClient);
+        List partitions = scala.collection.JavaConversions.seqAsJavaList(metadata.partitionsMetadata());
+        System.out.println(partitions.size());
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestReadKafkaWithOffsetRange.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestReadKafkaWithOffsetRange.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import java.util.*;
+
+/**
+ * Read kafka message for a specific offset range
+ */
+public class TestReadKafkaWithOffsetRange {
+    public static void main(String[] args) throws Exception{
+        int port = 6667;
+        String topic = "executorStateTopic_sandbox_eventSource";
+        int partition = 1;
+        KafkaReadWithOffsetRange test = new KafkaReadWithOffsetRange(Collections.singletonList("localhost"), port, topic, partition, new DeltaEventValueDeserializer());
+        test.readUntilMaxOffset(300, new DeltaEventReplayCallback() {
+            @Override
+            public void replay(Object event) {
+                System.out.println(event);
+            }
+        });
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestStateSnapshotEagleServiceDAOImpl.java
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/test/java/org/apache/eagle/state/deltaevent/TestStateSnapshotEagleServiceDAOImpl.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.state.deltaevent;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import junit.framework.Assert;
+import org.apache.eagle.state.snapshot.StateSnapshotDAO;
+import org.apache.eagle.state.snapshot.StateSnapshotEagleServiceDAOImpl;
+import org.junit.Test;
+
+/**
+ * test state snapshot read/write
+ */
+public class TestStateSnapshotEagleServiceDAOImpl {
+    @Test
+    public void testReadWrite() throws Exception{
+        System.setProperty("eagleProps.eagleService.host", "localhost");
+        System.setProperty("eagleProps.eagleService.port", "38080");
+        System.setProperty("eagleProps.eagleService.username", "admin");
+        System.setProperty("eagleProps.eagleService.password", "secret");
+        Config config = ConfigFactory.load();
+        StateSnapshotDAO dao = new StateSnapshotEagleServiceDAOImpl(config);
+        String stateString = "This is state snapshot";
+        dao.writeState("site1", "applicationId1", "executorId1", stateString.getBytes("UTF-8"));
+        byte[] state = dao.findLatestState("site1", "applicationId1", "executorId1").getState();
+        String recoveredStateString = new String(state, "UTF-8");
+        Assert.assertEquals(stateString, recoveredStateString);
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-executor-state/src/test/resources/application.conf
+++ b/eagle-core/eagle-data-process/eagle-executor-state/src/test/resources/application.conf
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+	"envContextConfig" : {
+		"env" : "storm",
+		"mode" : "local",
+		"topologyName" : "kafka-monitor-topology",
+		"parallelismConfig" : {
+			"kafkaMsgConsumer" : 1
+		}
+	},
+	"dataSourceConfig": {
+		"topic" : "sample_event",
+		"zkConnection" : "localhost:2181",
+		"zkConnectionTimeoutMS" : 15000,
+		"consumerGroupId" : "EagleConsumer",
+		"fetchSize" : 1048586,
+		"transactionZKServers" : "localhost",
+		"transactionZKPort" : 2181,
+		"transactionZKRoot" : "/consumers",
+		"transactionStateUpdateMS" : 2000
+	},
+	"alertExecutorConfigs" : {
+		"eventStreamExecutor" : {
+			"parallelism" : 1,
+			"partitioner" : "org.apache.eagle.alert.policy.DefaultPolicyPartitioner"
+			"needValidation" : "true"
+		}
+	},
+	"eagleProps" : {
+		"site" : "sandbox",
+		"dataSource": "eventSource",
+		"dataJoinPollIntervalSec" : 30,
+		"mailHost" : "mail.host.com",
+		"mailSmtpPort":"25",
+		"mailDebug" : "true",
+		"eagleService": {
+			"host": "localhost",
+			"port": 38080,
+			"username": "admin",
+			"password": "secret"
+		},
+    "executorState" : {
+      "snapshotIntervalMS" : 10000,
+      "topicBase" : "executorStateTopic",
+      "zkClientConnection" : "localhost:2181",
+      "brokerList" : "localhost",
+      "brokerPort" : 6667,
+      "deltaEventKafkaProducerConfig" : {
+        "bootstrap.servers" : "localhost:6667",
+        "key.serializer" : "org.apache.eagle.state.deltaevent.DeltaEventKeySerializer",
+        "value.serializer" : "org.apache.eagle.state.deltaevent.DeltaEventValueSerializer"
+      },
+      "deltaEventKafkaConsumerConfig" : {
+        "valueDeserializer" : "org.apache.eagle.state.deltaevent.DeltaEventValueDeserializer",
+        "partition.assignment.strategy" : "[org.apache.kafka.clients.consumer.RangeAssignor]",
+        "group.id" : "deltaEventConsumer",
+        "enable.auto.commit" : "true",
+        "auto.commit.interval.ms" : "10000"
+      }
+    }
+	},
+	"dynamicConfigSource" : {
+		"enabled" : true,
+		"initDelayMillis" : 0,
+		"delayMillis" : 30000
+	}
+}

--- a/eagle-core/eagle-data-process/eagle-stream-process-api/src/main/scala/org/apache/eagle/datastream/storm/StormBoltFactory.scala
+++ b/eagle-core/eagle-data-process/eagle-stream-process-api/src/main/scala/org/apache/eagle/datastream/storm/StormBoltFactory.scala
@@ -30,10 +30,10 @@ object StormBoltFactory {
       case FlatMapProducer(worker) => {
         if(worker.isInstanceOf[JavaStormStreamExecutor[EagleTuple]]){
           worker.asInstanceOf[JavaStormStreamExecutor[EagleTuple]].prepareConfig(config)
-          JavaStormBoltWrapper(worker.asInstanceOf[JavaStormStreamExecutor[EagleTuple]])
+          JavaStormBoltWrapper(config, worker.asInstanceOf[JavaStormStreamExecutor[EagleTuple]])
         }else if(worker.isInstanceOf[StormStreamExecutor[EagleTuple]]){
           worker.asInstanceOf[StormStreamExecutor[EagleTuple]].prepareConfig(config)
-          StormBoltWrapper(worker.asInstanceOf[StormStreamExecutor[EagleTuple]])
+          StormBoltWrapper(config, worker.asInstanceOf[StormStreamExecutor[EagleTuple]])
         }else {
           throw new UnsupportedOperationException
         }

--- a/eagle-core/eagle-data-process/eagle-stream-process-api/src/main/scala/org/apache/eagle/datastream/storm/StormBoltWrapper.scala
+++ b/eagle-core/eagle-data-process/eagle-stream-process-api/src/main/scala/org/apache/eagle/datastream/storm/StormBoltWrapper.scala
@@ -22,12 +22,13 @@ import backtype.storm.task.{OutputCollector, TopologyContext}
 import backtype.storm.topology.OutputFieldsDeclarer
 import backtype.storm.topology.base.BaseRichBolt
 import backtype.storm.tuple.{Fields, Tuple}
+import com.typesafe.config.Config
 import org.apache.eagle.datastream.{Collector, EagleTuple, StormStreamExecutor}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 
-case class StormBoltWrapper(worker : StormStreamExecutor[EagleTuple]) extends BaseRichBolt{
+case class StormBoltWrapper(config : Config, worker : StormStreamExecutor[EagleTuple]) extends BaseRichBolt{
   val LOG = LoggerFactory.getLogger(StormBoltWrapper.getClass)
   var _collector : OutputCollector = null
 

--- a/eagle-core/eagle-data-process/eagle-stream-process-api/src/test/java/org/apache/eagle/datastream/storm/TestJavaStormBoltWrapper.java
+++ b/eagle-core/eagle-data-process/eagle-stream-process-api/src/test/java/org/apache/eagle/datastream/storm/TestJavaStormBoltWrapper.java
@@ -1,0 +1,250 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.datastream.storm;
+
+import backtype.storm.generated.GlobalStreamId;
+import backtype.storm.task.IOutputCollector;
+import backtype.storm.task.OutputCollector;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.MessageId;
+import backtype.storm.tuple.Tuple;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.eagle.alert.dao.AlertDefinitionDAOImpl;
+import org.apache.eagle.alert.policy.DefaultPolicyPartitioner;
+import org.apache.eagle.datastream.JavaStormStreamExecutor;
+import org.apache.eagle.executor.AlertExecutor;
+import org.apache.eagle.service.client.EagleServiceConnector;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * test JavaStormBoltWrapper
+ */
+public class TestJavaStormBoltWrapper {
+    private static final Logger LOG = LoggerFactory.getLogger(TestJavaStormBoltWrapper.class);
+
+    public static void main(String[] args) throws Exception{
+        Config config = ConfigFactory.load();
+        EagleServiceConnector connector = new EagleServiceConnector(config);
+        String streamName = "eventStream";
+        AlertExecutor executor = new AlertExecutor("eventStreamExecutor",
+                new DefaultPolicyPartitioner(), 1, 0,
+                new AlertDefinitionDAOImpl(connector),
+                new String[]{streamName});
+        executor.prepareConfig(config);
+        JavaStormBoltWrapper bolt = new JavaStormBoltWrapper(config, (JavaStormStreamExecutor)executor);
+        bolt.prepare(null, null, getOutputCollector());
+        TreeMap map = new TreeMap();
+        map.put("name", "xyzzzz");
+        map.put("value", 100);
+        map.put("timestamp", 14786203663L);
+        while(true) {
+            LOG.info("sending message ...");
+            Tuple tuple = new TestTuple("key1", streamName, map);
+            bolt.execute(tuple);
+            Thread.sleep(1000);
+        }
+    }
+
+    private static OutputCollector getOutputCollector(){
+        return new OutputCollector(new IOutputCollector(){
+            @Override
+            public List<Integer> emit(String streamId, Collection<Tuple> anchors, List<Object> tuple) {
+                return null;
+            }
+            @Override
+            public void emitDirect(int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple) {
+            }
+            @Override
+            public void ack(Tuple input) {
+            }
+            @Override
+            public void fail(Tuple input) {
+            }
+            @Override
+            public void reportError(Throwable error) {
+            }
+        });
+    }
+
+    private static class TestTuple implements Tuple{
+        private String key;
+        private String streamName;
+        private SortedMap map;
+        public TestTuple(final String key, final String streamName, final SortedMap map){
+            this.key = key;
+            this.streamName = streamName;
+            this.map = map;
+        }
+        @Override
+        public GlobalStreamId getSourceGlobalStreamid() {
+            return null;
+        }
+        @Override
+        public String getSourceComponent() {
+            return null;
+        }
+        @Override
+        public int getSourceTask() {
+            return 0;
+        }
+        @Override
+        public String getSourceStreamId() {
+            return null;
+        }
+        @Override
+        public MessageId getMessageId() {
+            return null;
+        }
+        @Override
+        public int size() {
+            return 0;
+        }
+        @Override
+        public boolean contains(String field) {
+            return false;
+        }
+        @Override
+        public Fields getFields() {
+            return null;
+        }
+        @Override
+        public int fieldIndex(String field) {
+            return 0;
+        }
+        @Override
+        public List<Object> select(Fields selector) {
+            return null;
+        }
+
+        @Override
+        public Object getValue(int i) {
+            return null;
+        }
+
+        @Override
+        public String getString(int i) {
+            return null;
+        }
+
+        @Override
+        public Integer getInteger(int i) {
+            return null;
+        }
+
+        @Override
+        public Long getLong(int i) {
+            return null;
+        }
+
+        @Override
+        public Boolean getBoolean(int i) {
+            return null;
+        }
+
+        @Override
+        public Short getShort(int i) {
+            return null;
+        }
+
+        @Override
+        public Byte getByte(int i) {
+            return null;
+        }
+
+        @Override
+        public Double getDouble(int i) {
+            return null;
+        }
+
+        @Override
+        public Float getFloat(int i) {
+            return null;
+        }
+
+        @Override
+        public byte[] getBinary(int i) {
+            return new byte[0];
+        }
+
+        @Override
+        public Object getValueByField(String field) {
+            return null;
+        }
+
+        @Override
+        public String getStringByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Integer getIntegerByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Long getLongByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Boolean getBooleanByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Short getShortByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Byte getByteByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Double getDoubleByField(String field) {
+            return null;
+        }
+
+        @Override
+        public Float getFloatByField(String field) {
+            return null;
+        }
+
+        @Override
+        public byte[] getBinaryByField(String field) {
+            return new byte[0];
+        }
+
+        @Override
+        public List<Object> getValues() {
+            List<Object> ret = new ArrayList<Object>();
+            ret.add(key);
+            ret.add(streamName);
+            ret.add(map);
+            return ret;
+        }
+    }
+}

--- a/eagle-core/eagle-data-process/eagle-stream-process-api/src/test/resources/application.conf
+++ b/eagle-core/eagle-data-process/eagle-stream-process-api/src/test/resources/application.conf
@@ -52,7 +52,27 @@
 			"port": 38080,
 			"username": "admin",
 			"password": "secret"
-		}
+		},
+    "executorState" : {
+      "enabled" : true,
+      "snapshotIntervalMS" : 10000,
+      "topicBase" : "executorStateTopic",
+      "zkClientConnection" : "localhost:2181",
+      "brokerList" : "localhost",
+      "brokerPort" : 6667,
+      "deltaEventKafkaProducerConfig" : {
+        "bootstrap.servers" : "localhost:6667",
+        "key.serializer" : "org.apache.eagle.state.deltaevent.DeltaEventKeySerializer",
+        "value.serializer" : "org.apache.eagle.state.deltaevent.DeltaEventValueSerializer"
+      },
+      "deltaEventKafkaConsumerConfig" : {
+        "valueDeserializer" : "org.apache.eagle.state.deltaevent.DeltaEventValueDeserializer",
+        "partition.assignment.strategy" : "[org.apache.kafka.clients.consumer.RangeAssignor]",
+        "group.id" : "deltaEventConsumer",
+        "enable.auto.commit" : "true",
+        "auto.commit.interval.ms" : "10000"
+      }
+    }
 	},
 	"dynamicConfigSource" : {
 		"enabled" : true,

--- a/eagle-core/eagle-embed/eagle-embed-hbase/pom.xml
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/pom.xml
@@ -47,10 +47,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.slf4j</groupId>-->
+            <!--<artifactId>log4j-over-slf4j</artifactId>-->
+        <!--</dependency>-->
     </dependencies>
 
     <build>

--- a/eagle-core/eagle-embed/eagle-embed-hbase/src/main/java/org/apache/eagle/service/hbase/Tables.java
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/src/main/java/org/apache/eagle/service/hbase/Tables.java
@@ -43,6 +43,10 @@ public class Tables {
         tables.add("ipzone");
         tables.add("mlmodel");
         tables.add("userprofile");
+
+        // for executor state management
+        tables.add("policyStateSnapshot");
+        tables.add("deltaEventIdRange");
     }
 
     public List<String> getTables(){

--- a/eagle-core/eagle-embed/eagle-embed-server/pom.xml
+++ b/eagle-core/eagle-embed/eagle-embed-server/pom.xml
@@ -65,6 +65,10 @@
        		<groupId>org.slf4j</groupId>
 			<artifactId>log4j-over-slf4j</artifactId>
       	</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
 	</dependencies>
     <build>
         <plugins>

--- a/eagle-core/eagle-embed/eagle-embed-server/src/test/java/org/apache/eagle/service/embedded/tomcat/TestEmbeddedServer.java
+++ b/eagle-core/eagle-embed/eagle-embed-server/src/test/java/org/apache/eagle/service/embedded/tomcat/TestEmbeddedServer.java
@@ -16,9 +16,10 @@
  */
 package org.apache.eagle.service.embedded.tomcat;
 
+import org.junit.Test;
+
 public class TestEmbeddedServer {
-	
-	//@Test
+	@Test
 	public void test() throws Throwable{
 		String webappDirLocation = "../../../eagle-webservice/target/eagle-service";
 		EmbeddedServer.getInstance(webappDirLocation);

--- a/eagle-core/eagle-query/eagle-entity-base/src/main/java/org/apache/eagle/log/entity/meta/ByteArraySerDeser.java
+++ b/eagle-core/eagle-query/eagle-entity-base/src/main/java/org/apache/eagle/log/entity/meta/ByteArraySerDeser.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.eagle.log.entity.meta;
+
+/**
+ * serialize byte array which is stored like the following
+ */
+public class ByteArraySerDeser implements EntitySerDeser<byte[]>{
+    @Override
+    public byte[] deserialize(byte[] bytes) {
+        byte[] ret = new byte[bytes.length];
+        System.arraycopy(bytes, 0, ret, 0, bytes.length);
+        return ret;
+    }
+
+    @Override
+    public byte[] serialize(byte[] bytes) {
+        byte[] ret = new byte[bytes.length];
+        System.arraycopy(bytes, 0, ret, 0, bytes.length);
+        return ret;
+    }
+
+    @Override
+    public Class<byte[]> type() {
+        return byte[].class;
+    }
+}

--- a/eagle-core/eagle-query/eagle-entity-base/src/main/java/org/apache/eagle/log/entity/meta/EntityDefinitionManager.java
+++ b/eagle-core/eagle-query/eagle-entity-base/src/main/java/org/apache/eagle/log/entity/meta/EntityDefinitionManager.java
@@ -85,6 +85,10 @@ public class EntityDefinitionManager {
 		_serDeserMap.put(int[].class, new IntArraySerDeser());
 		_serIDDeserClassMap.put(id, int[].class);
 		_serDeserClassIDMap.put(int[].class, id++);
+
+        _serDeserMap.put(byte[].class, new ByteArraySerDeser());
+        _serIDDeserClassMap.put(id, byte[].class);
+        _serDeserClassIDMap.put(byte[].class, id++);
 		
 		_serDeserMap.put(double[].class, new DoubleArraySerDeser());
 		_serIDDeserClassMap.put(id, double[].class);

--- a/eagle-core/eagle-query/eagle-entity-base/src/main/java/org/apache/eagle/log/entity/meta/Prefix.java
+++ b/eagle-core/eagle-query/eagle-entity-base/src/main/java/org/apache/eagle/log/entity/meta/Prefix.java
@@ -21,6 +21,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * prefix sits in the leading place of an Eagle entity row key, there are 2 potential benefits by using prefix
+ * 1. with prefix we can distribute different table into different region potentially. In this case, we can assign static prefix string while defining entity
+ * 2. with prefix we can put different metrics into one table but may be distributed into different regions. In this case, user can assign different prefix programatically
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Prefix {

--- a/eagle-security/eagle-security-hdfs-auditlog/src/main/java/org/apache/eagle/security/auditlog/HdfsAuditLogKafkaDeserializer.java
+++ b/eagle-security/eagle-security-hdfs-auditlog/src/main/java/org/apache/eagle/security/auditlog/HdfsAuditLogKafkaDeserializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.eagle.security.auditlog;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
@@ -31,6 +32,7 @@ import org.apache.eagle.security.hdfs.HDFSAuditLogObject;
 public class HdfsAuditLogKafkaDeserializer implements SpoutKafkaMessageDeserializer{
 	private static Logger LOG = LoggerFactory.getLogger(HdfsAuditLogKafkaDeserializer.class);
 	private Properties props;
+    private final static String CHARSET = "UTF-8";
 
 	public  HdfsAuditLogKafkaDeserializer(Properties props){
 		this.props = props;
@@ -43,7 +45,12 @@ public class HdfsAuditLogKafkaDeserializer implements SpoutKafkaMessageDeseriali
 	 */
 	@Override
 	public Object deserialize(byte[] arg0) {
-		String logLine = new String(arg0);
+		String logLine = null;
+        try{
+            logLine = new String(arg0, CHARSET);
+        }catch(UnsupportedEncodingException ex){
+            throw new RuntimeException(ex);
+        }
 
 		HDFSAuditLogParser parser = new HDFSAuditLogParser();
 		HDFSAuditLogObject entity = null;

--- a/pom.xml
+++ b/pom.xml
@@ -250,10 +250,17 @@
         <!-- sprint security -->
         <spring.framework.version>3.1.2.RELEASE</spring.framework.version>
 
+        <!-- zkclient -->
+        <com.101tec.zkclient.version>0.3</com.101tec.zkclient.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.101tec</groupId>
+                <artifactId>zkclient</artifactId>
+                <version>${com.101tec.zkclient.version}</version>
+            </dependency>
             <!-- Commons Dependencies-->
             <dependency>
                 <groupId>commons-cli</groupId>


### PR DESCRIPTION
executor state management mainly for policy state durability for failover
1. basic implementation of state snapshot, delta event persistence, snapshot recover, delta event recovery
2. by default it is disabled
3. need improve: batch insert delta events to kafka, and batch ack storm
4. need performance test further.