### PR TITLE
Eagle-147 add pmd maven plugin and eagle-qe module

### DIFF
--- a/eagle-qe/pom.xml
+++ b/eagle-qe/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/eagle-qe/pom.xml
+++ b/eagle-qe/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eagle</groupId>
+    <artifactId>eagle-qe</artifactId>
+    <version>1.0.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.6</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/eagle-qe/src/main/resources/pmd_rules.xml
+++ b/eagle-qe/src/main/resources/pmd_rules.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <ruleset name="Custom ruleset"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/eagle-qe/src/main/resources/pmd_rules.xml
+++ b/eagle-qe/src/main/resources/pmd_rules.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruleset name="Custom ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        This ruleset checks my code for bad stuff
+    </description>
+
+    <!-- We'll use the entire 'strings' ruleset -->
+    <rule ref="rulesets/java/strings.xml"/>
+
+    <!-- Here's some rules we'll specify one at a time -->
+    <rule ref="rulesets/java/unusedcode.xml/UnusedLocalVariable"/>
+    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateField"/>
+    <rule ref="rulesets/java/imports.xml/DuplicateImports"/>
+    <rule ref="rulesets/java/basic.xml/UnnecessaryConversionTemporary"/>
+
+    <!-- We want to customize this rule a bit, change the message and raise the priority  -->
+    <rule
+            ref="rulesets/java/basic.xml/EmptyCatchBlock"
+            message="Must handle exceptions">
+        <priority>2</priority>
+    </rule>
+
+    <!-- Now we'll customize a rule's property value -->
+    <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="5"/>
+        </properties>
+    </rule>
+
+    <!-- We want everything from braces.xml except WhileLoopsMustUseBraces -->
+    <rule ref="rulesets/java/braces.xml">
+        <exclude name="WhileLoopsMustUseBraces"/>
+    </rule>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
         <module>eagle-examples</module>
         <module>eagle-gc</module>
         <module>eagle-hadoop-metric</module>
+        <module>eagle-qe</module>
     </modules>
     <properties>
         <!-- General Properties -->
@@ -935,11 +936,11 @@
                                 <exclude>**/webapp/**</exclude>
 
                             </excludes>
-                         </configuration>
-                     </execution>
-                 </executions>
-             </plugin>
-         </plugins>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
         <maven-tomcat7.version>2.2</maven-tomcat7.version>
         <maven-apache-rat.version>0.11</maven-apache-rat.version>
         <maven-failsafe.version>2.6</maven-failsafe.version>
+        <maven-pmd.version>3.6</maven-pmd.version>
 
         <!-- Environment Versions-->
         <hadoop.version>2.6.0.2.2.5.1-3</hadoop.version>
@@ -255,6 +256,7 @@
         <scala-reflect.version>2.10.0</scala-reflect.version>
         <mockito.version>1.8.1-rc1</mockito.version>
         <tomcat.embed.version>7.0.55</tomcat.embed.version>
+        <eagle-qe.version>1.0.0</eagle-qe.version>
 
         <!-- Machine Learning -->
         <ejml.version>0.25</ejml.version>
@@ -868,6 +870,18 @@
                     <artifactId>scalatest-maven-plugin</artifactId>
                     <version>${maven-scalatest.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>${maven-pmd.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>eagle</groupId>
+                            <artifactId>eagle-qe</artifactId>
+                            <version>${eagle-qe.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -939,6 +953,19 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <linkXRef>true</linkXRef>
+                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                    <targetJdk>${java.version}</targetJdk>
+                    <aggregate>true</aggregate>
+                    <rulesets>
+                        <ruleset>pmd_rules.xml</ruleset>
+                    </rulesets>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
1. in order to enable static code check, add pmd maven plugin in incubator-eagle/pom.xml
2. in order to provide a configurable pmd ruleset file and have it visible for all submodules without configuring it in each submodule's pom file, add a eagle-qe module in incubator-eagle/pom.xml, containing pmd_rules.xml as a resource, so that after compilation, the xml file could locate in classpath for all submodules to find