### PR TITLE
EAGLE-202 Fix primary key length for mysql and add mysql webservice configuration

### DIFF
--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntitySchemaManager.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntitySchemaManager.java
@@ -179,8 +179,7 @@ public class JdbcEntitySchemaManager implements IJdbcEntityDDLManager {
         pkColumn.setPrimaryKey(true);
         pkColumn.setRequired(true);
         pkColumn.setTypeCode(Types.VARCHAR);
-        pkColumn.setSize("1024");
-//        pkColumn.setSizeAndScale(1024,10240);
+//        pkColumn.setSize("256");
 
         pkColumn.setDescription("eagle entity row-key column");
         table.addColumn(pkColumn);

--- a/eagle-webservice/src/main/resources/application-mysql.conf
+++ b/eagle-webservice/src/main/resources/application-mysql.conf
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+eagle {
+	service {
+		storage-type="jdbc"
+		storage-adapter="mysql"
+		storage-username="eagle"
+		storage-password=eagle
+		storage-database=eagle
+		storage-connection-url="jdbc:mysql://localhost:3306/eagle"
+		storage-connection-props="encoding=UTF-8"
+		storage-driver-class="com.mysql.jdbc.Driver"
+		storage-connection-max=8
+	}
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-202

It didn’t create the required 24 tables automatically.
Error : Specified key was too long; max key length is 1000 bytes
Cause : for UUID columns which is primary key the length is 1024.
Fix : Change length for PK(UUID) columns to 100 and created tables manually.
