### PR TITLE
EAGLE-274 Fix java.lang.ClassNotFoundException: org.slf4j.impl.Log4jLoggerAdapter

### DIFF
--- a/eagle-assembly/src/assembly/eagle-bin.xml
+++ b/eagle-assembly/src/assembly/eagle-bin.xml
@@ -216,8 +216,10 @@
                 <include>slf4j-*.jar</include>
                 <include>log4j-*.jar</include>
                 <include>commons-math3-*.jar</include>
-                <include>slf4j-log4j12-*.jar</include>
             </includes>
+            <excludes>
+                <exclude>slf4j-log4j12-*.jar</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/target/lib</directory>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-274

slf4j-log4j12-*.jar under lib/share conflicts with Storm jars