### PR TITLE
EAGLE-300 set debug-log dumping components' log level to INFO

### DIFF
--- a/eagle-webservice/src/main/resources/log4j.properties
+++ b/eagle-webservice/src/main/resources/log4j.properties
@@ -19,3 +19,8 @@ log4j.rootLogger=DEBUG, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %p [%t] %c{2}[%L]: %m%n
+
+# set log level as INFO for debug-log dumping components
+log4j.category.org.springframework=INFO
+log4j.category.org.apache.torque=INFO
+log4j.category.org.commons=INFO


### PR DESCRIPTION
Previously, when trying to find meaningful logs of eagle, there were too many DEBUG log lines in service log file. The redundancy ratio could be found as this: within a 1.5GB log file, only 25+MB log lines are at INFO and ERROR level. Therefore, modify log4j configuration to ignore debug-log dumping from springframework, apache.commons, and apache.torque.

Please help review this PR. Thanks.