### PR TITLE
EAGLE-291 : JDBC: Update transactions fail in PostgreSQL

### DIFF
--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/entity/impl/JdbcEntityWriterImpl.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/entity/impl/JdbcEntityWriterImpl.java
@@ -66,7 +66,7 @@ public class JdbcEntityWriterImpl<E extends TaggedLogAPIEntity> implements JdbcE
         stopWatch.start();
         Connection connection = null;
         Savepoint insertDup = null;
-
+        int i = 0 ;
         try {
             connection = ConnectionManagerFactory.getInstance().getConnection();
             // set auto commit false and commit by hands for 3x~5x better performance
@@ -79,7 +79,8 @@ public class JdbcEntityWriterImpl<E extends TaggedLogAPIEntity> implements JdbcE
                 ObjectKey key = null;
                 try {
                     //save point , so that we can roll back just current entry, if required.
-                    insertDup = connection.setSavepoint("insertEntity");
+                    i++ ;
+                    insertDup = connection.setSavepoint("insertEntity"+i);
                     // TODO: implement batch insert for better performance
                     key = peer.delegate().doInsert(columnValues,connection);
 


### PR DESCRIPTION
The transactions in Postgres was failing due to insert fail transaction already in progress and we were trying to update if insert fails. Need to rollback the failed insert transaction and then continue with update transaction. Postgres is more strict as compared to MySql, so we need save point so that we can roll it back, if required.