### PR TITLE
EAGLE-326 fix typo '.app' to be 'app.'

### DIFF
--- a/eagle-docs/tutorial/application_manager_tutorial.md
+++ b/eagle-docs/tutorial/application_manager_tutorial.md
@@ -43,7 +43,7 @@ The configuration file `eagle-scheduler.conf` defines scheduler parameters, exec
     
     Some default topology properties are defined here. 
     
-Note: these configurations can be overridden in the topology configurations, which is shown below. The only difference is to add a prefix `.app`. For example, 'app.envContextConfig.jarFile' is to override 'envContextConfig.jarFile' in eagle-schedule.conf
+Note: these configurations can be overridden in the topology configurations, which is shown below. The only difference is to add a prefix `app.`. For example, 'app.envContextConfig.jarFile' is to override 'envContextConfig.jarFile' in eagle-schedule.conf
    
   
 #### Manual


### PR DESCRIPTION
This typo may impact configuration of applications.