### PR TITLE
EAGLE-319 modify java to jdbc data type mapping to be compatible with derby DB

### DIFF
--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntityDefinitionManager.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntityDefinitionManager.java
@@ -150,7 +150,7 @@ public class JdbcEntityDefinitionManager {
     // Initially bind basic java types with SQL types
     //================================================
     static {
-        registerJdbcType(String.class, Types.LONGVARCHAR);
+        registerJdbcType(String.class, Types.VARCHAR);
         registerJdbcType(Integer.class, Types.INTEGER);
         registerJdbcType(Double.class, Types.DOUBLE);
         registerJdbcType(Float.class, Types.FLOAT);


### PR DESCRIPTION
modify java to jdbc data type mapping: long-varchar to varchar, to avoid comparison error for derby DB