### PR TITLE
EAGLE-330 Fix Hive ql.Parser can't parser a hive query sql with keywords.

### DIFF
--- a/eagle-security/eagle-security-hive/src/main/java/org/apache/eagle/security/hive/ql/Parser.java
+++ b/eagle-security/eagle-security-hive/src/main/java/org/apache/eagle/security/hive/ql/Parser.java
@@ -16,11 +16,19 @@
  */
 package org.apache.eagle.security.hive.ql;
 
+import org.antlr.runtime.RecognitionException;
+import org.antlr.runtime.Token;
+import org.antlr.runtime.TokenRewriteStream;
+import org.antlr.runtime.TokenStream;
+import org.antlr.runtime.tree.CommonTree;
+import org.antlr.runtime.tree.CommonTreeAdaptor;
+import org.antlr.runtime.tree.TreeAdaptor;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.lib.Node;
+import org.apache.hadoop.hive.ql.parse.ASTErrorNode;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.ParseDriver;
-import org.apache.hadoop.hive.ql.parse.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +40,21 @@ import java.util.Set;
 
 public class Parser {
   private static final Logger LOG = LoggerFactory.getLogger(Parser.class);
+
+  static final TreeAdaptor adaptor = new CommonTreeAdaptor() {
+    @Override
+    public Object create(Token payload) {
+      return new ASTNode(payload);
+    }
+    @Override
+    public Object dupNode(Object t) {
+      return create(((CommonTree)t).token);
+    }
+    @Override
+    public Object errorNode(TokenStream input, Token start, Token stop, RecognitionException e) {
+      return new ASTErrorNode(input, start, stop, e);
+    }
+  };
 
   private Set<String> tableSet;
   private Set<String> columnSet;
@@ -66,11 +89,26 @@ public class Parser {
    * Parse an Hive QL into an Abstract Syntax Tree(AST).
    * @param query
    * @return
-   * @throws ParseException
+   * @throws RecognitionException
    */
-  public ASTNode generateAST(String query) throws ParseException {
+  public ASTNode generateAST(String query) throws RecognitionException {
+    // https://issues.apache.org/jira/browse/HIVE-10731
+    // https://issues.apache.org/jira/browse/HIVE-6617
+    HiveConf hiveConf = new HiveConf();
+    hiveConf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS, false);
+
     ParseDriver pd = new ParseDriver();
-    return pd.parse(query);
+    ParseDriver.ANTLRNoCaseStringStream antlrStream = pd.new ANTLRNoCaseStringStream(query);
+    ParseDriver.HiveLexerX lexer = pd.new HiveLexerX(antlrStream);
+    lexer.setHiveConf(hiveConf);
+    TokenRewriteStream tokens = new TokenRewriteStream(lexer);
+
+    HiveParser parser = new HiveParser(tokens);
+    parser.setHiveConf(hiveConf);
+    parser.setTreeAdaptor(adaptor);
+    HiveParser.statement_return r = parser.statement();
+
+    return (ASTNode)r.getTree();
   }
 
   private void parseQL(ASTNode ast) {

--- a/eagle-security/eagle-security-hive/src/test/java/org/apache/eagle/security/hive/ql/TestParser.java
+++ b/eagle-security/eagle-security-hive/src/test/java/org/apache/eagle/security/hive/ql/TestParser.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.hive.ql.parse.ASTNode;
-import org.apache.hadoop.hive.ql.parse.ParseException;
+import org.antlr.runtime.RecognitionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class TestParser {
     }
   }
 
-  public void printQueryAST(String query) throws ParseException {
+  public void printQueryAST(String query) throws RecognitionException {
     ASTNode root = parser.generateAST(query);
     printTree(root, 0);
   }
@@ -205,6 +205,32 @@ public class TestParser {
         String expectedOperation = "SELECT";
         String expectedInsertTable = "t1";
         Map<String, Set<String>> expectedTableColumn = null;
+        _testParsingQuery(query, expectedOperation, expectedInsertTable, expectedTableColumn);
+    }
+
+    @Test
+    public void testQueryWithKeyWords() throws Exception {
+        String query =  "SELECT id, user FROM db.table1";
+        String expectedOperation = "SELECT";
+        String expectedInsertTable = null;
+        Map<String, Set<String>> expectedTableColumn = new HashMap<String, Set<String>>();
+        Set<String> set = new HashSet<String>();
+        set.add("id");
+        set.add("user");
+        expectedTableColumn.put("db.table1", set);
+        _testParsingQuery(query, expectedOperation, expectedInsertTable, expectedTableColumn);
+    }
+
+    @Test
+    public void testInsertTableWithKeyWords() throws Exception {
+        String query =  "INSERT OVERWRITE TABLE table2 SELECT id, user FROM db.table1";
+        String expectedOperation = "SELECT";
+        String expectedInsertTable = "table2";
+        Map<String, Set<String>> expectedTableColumn = new HashMap<String, Set<String>>();
+        Set<String> set = new HashSet<String>();
+        set.add("id");
+        set.add("user");
+        expectedTableColumn.put("db.table1", set);
         _testParsingQuery(query, expectedOperation, expectedInsertTable, expectedTableColumn);
     }
 


### PR DESCRIPTION
[EAGLE-330](https://issues.apache.org/jira/browse/EAGLE-330):Fix Hive ql.Parser can't parser a hive query sql with keywords
Updated Parser.java and TestParser.java