### PR TITLE
EAGLE-333 Fix hive.ql.Parser can't parse complex SQL.

### DIFF
--- a/eagle-security/eagle-security-hive/src/main/java/org/apache/eagle/security/hive/ql/Parser.java
+++ b/eagle-security/eagle-security-hive/src/main/java/org/apache/eagle/security/hive/ql/Parser.java
@@ -303,7 +303,7 @@ public class Parser {
         }
         break;
 
-      case HiveParser.TOK_FUNCTION:
+      case HiveParser.TOK_FUNCTION: case HiveParser.TOK_FUNCTIONDI:
         // Traverse children to get TOK_TABLE_OR_COL
         Set<String> tempSet = new HashSet<>();
         parseTokFunction(asn, tempSet);
@@ -337,14 +337,14 @@ public class Parser {
         String colRealName = convAliasToReal(columnAliasMap, ast.getChild(0).getText());
         set.add(colRealName);
         break;
-      case HiveParser.TOK_FUNCTION:
+      // Not only HiveParser.TOK_FUNCTION, but also HiveParser.KW_ADD, HiveParser.KW_WHEN ...
+      default:
         for (int i = 0; i < ast.getChildCount(); i++) {
           ASTNode n = (ASTNode)ast.getChild(i);
           if (n != null) {
             parseTokFunction(n, set);
           }
         }
-        break;
     }
   }
 

--- a/eagle-security/eagle-security-hive/src/test/java/org/apache/eagle/security/hive/ql/TestParser.java
+++ b/eagle-security/eagle-security-hive/src/test/java/org/apache/eagle/security/hive/ql/TestParser.java
@@ -235,6 +235,40 @@ public class TestParser {
     }
 
     @Test
+    public void testCountDistinct() throws Exception {
+        String query =  "SELECT count(distinct id) FROM db.table1";
+        String expectedOperation = "SELECT";
+        Map<String, Set<String>> expectedTableColumn = new HashMap<String, Set<String>>();
+        Set<String> set = new HashSet<String>();
+        set.add("id");
+        expectedTableColumn.put("db.table1", set);
+        _testParsingQuery(query, expectedOperation, null, expectedTableColumn);
+    }
+
+    @Test
+    public void testComplextQuery() throws Exception {
+        String query =  "SELECT id, \n" +
+                "  SUM(CASE WHEN(type=1 AND ds < '2016-05-12' AND category IN ('1', '2')) " +
+                "    THEN 1 ELSE 0 end) / COUNT(DISTINCT id) AS col1, \n" +
+                "  CASE WHEN SUM(CASE WHEN type=1 THEN 1 ELSE 0 END)=0 THEN 0 " +
+                "    ELSE SUM(CASE WHEN type=1 AND DATEDIFF('2016-05-21', ds)=1 " +
+                "    THEN 1 ELSE 0 END) * DATEDIFF('2016-05-21', '2016-04-21') / " +
+                "    SUM(CASE WHEN type=1 THEN 1 ELSE 0 END) END AS col2 \n" +
+                "FROM db.table1 \n" +
+                "WHERE ds < '2016-05-21' \n" +
+                "GROUP BY id";
+        String expectedOperation = "SELECT";
+        Map<String, Set<String>> expectedTableColumn = new HashMap<String, Set<String>>();
+        Set<String> set = new HashSet<String>();
+        set.add("id");
+        set.add("ds");
+        set.add("type");
+        set.add("category");
+        expectedTableColumn.put("db.table1", set);
+        _testParsingQuery(query, expectedOperation, null, expectedTableColumn);
+    }
+
+    @Test
     public void testCreateTable() throws Exception {
         String query = "CREATE TABLE page_view(viewTime INT, userid BIGINT,\n" +
                 "                page_url STRING, referrer_url STRING,\n" +


### PR DESCRIPTION
1. Use parseTokFunction() to parse HiveParser.TOK_FUNCTIONDI type.

[EAGLE-333](https://issues.apache.org/jira/browse/EAGLE-333)