### PR TITLE
EAGLE-340: refactor bin/eagle-sandbox-starter.sh to make it easier to use

### DIFF
--- a/eagle-assembly/src/main/examples/sample-sensitivity-resource-create.sh
+++ b/eagle-assembly/src/main/examples/sample-sensitivity-resource-create.sh
@@ -23,10 +23,12 @@ curl -u ${EAGLE_SERVICE_USER}:${EAGLE_SERVICE_PASSWD} -X POST -H 'Content-Type:a
 
 
 #### create hdfs sensitivity sample in sandbox
+echo ""
 echo "create hdfs sensitivity sample in sandbox... "
 curl -u ${EAGLE_SERVICE_USER}:${EAGLE_SERVICE_PASSWD} -X POST -H 'Content-Type:application/json' "http://${EAGLE_SERVICE_HOST}:${EAGLE_SERVICE_PORT}/eagle-service/rest/entities?serviceName=FileSensitivityService" -d '[{"tags":{"site" : "sandbox", "filedir":"/tmp/private"}, "sensitivityType": "PRIVATE"}]'
 
 #### create hbase sensitivity sample in sandbox
+echo ""
 echo "create hdfs sensitivity sample in sandbox... "
 curl -u ${EAGLE_SERVICE_USER}:${EAGLE_SERVICE_PASSWD} -X POST -H 'Content-Type:application/json' "http://${EAGLE_SERVICE_HOST}:${EAGLE_SERVICE_PORT}/eagle-service/rest/entities?serviceName=HbaseResourceSensitivityService" -d '[{"tags":{"site":"sandbox","hbaseResource":"default:alertStreamSchema"},"sensitivityType":"PrivateTable"}]'
 

--- a/eagle-webservice/src/main/resources/application.conf
+++ b/eagle-webservice/src/main/resources/application.conf
@@ -13,15 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-eagle{
-	service{
-		storage-type="hbase"
-		hbase-zookeeper-quorum="sandbox.hortonworks.com"
-		hbase-zookeeper-property-clientPort=2181
-		zookeeper-znode-parent="/hbase-unsecure",
-		springActiveProfile="sandbox"
-		audit-enabled=true
+eagle {
+	service {
+		storage-type="jdbc"
+		storage-adapter="derby"
+		storage-username="eagle"
+		storage-password=eagle
+		storage-database=eagle
+		storage-connection-url="jdbc:derby:/tmp/eagle-db-dev;create=true"
+		storage-connection-props="encoding=UTF-8"
+		storage-driver-class="org.apache.derby.jdbc.EmbeddedDriver"
+		storage-connection-max=8
 	}
 }
-


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-340

Two changes 
1. use Derby as default database for sandbox starter
2. use HiveQueryLog monitoring as a sample application