### PR TITLE
Eagle-301 fix the bug of breaking mysql row size when creating tables

### DIFF
--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/JdbcConstants.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/JdbcConstants.java
@@ -28,7 +28,9 @@ public class JdbcConstants {
     public static final String ROW_KEY_COLUMN_NAME = "uuid";
 
     public static final int DEFAULT_TYPE_FOR_COMPLEX_TYPE = Types.BLOB;
-    public static final int DEFAULT_VARCHAR_SIZE =30000;
+    public static final int DEFAULT_TAG_VARCHAR_SIZE =1024;
+//    public static final int DEFAULT_VARCHAR_SIZE =30000;
+    public static final int DEFAULT_VARCHAR_SIZE =7168;
 
     // Eagle JDBC Storage Configuration
     public final static String EAGLE_DB_USERNAME = "eagle.service.storage-username";

--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntitySchemaManager.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntitySchemaManager.java
@@ -155,7 +155,7 @@ public class JdbcEntitySchemaManager implements IJdbcEntityDDLManager {
         tagColumn.setTypeCode(Types.VARCHAR);
         tagColumn.setJavaName(tagName);
 //        tagColumn.setScale(1024);
-        tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_VARCHAR_SIZE));
+        tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_TAG_VARCHAR_SIZE));
         tagColumn.setDefaultValue(null);
         tagColumn.setDescription("eagle entity tag column for "+tagName);
         return tagColumn;
@@ -196,7 +196,7 @@ public class JdbcEntitySchemaManager implements IJdbcEntityDDLManager {
 //            Index index = new UniqueIndex();
             for (String tag : entityDefinition.getInternal().getTags()) {
                 Column tagColumn = createTagColumn(tag);
-                tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_VARCHAR_SIZE));
+//                tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_TAG_VARCHAR_SIZE));
                 table.addColumn(tagColumn);
 //                IndexColumn indexColumn = new IndexColumn();
 //                indexColumn.setName(tag);


### PR DESCRIPTION
1. Add a constant varchar size for default "tag" columns as 1024.
2. Modify default max varchar size from 30000 to 7168.

The above 2 sizes are calculated with the table that requires the most on the 2 categories of varchar columns.