### PR TITLE
EAGLE-345 Removing -SNAPSHOT from 0.4 release branch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,114 @@
+
+Release Notes - Eagle - Version v0.4.0
+
+** Highlights **
+    * JBDC Metadata Storage Extension
+    * Topology management in remote mode including start/stop/status operations
+    * Auditlogparser for MapR's audit log
+    * Oozie auditlog integration for Oozie security monitoring
+    * Add applicaiton "maprFSAuditLog"
+    * Refactor bin/eagle-sandbox-starter.sh to make it easier to use
+
+** New Feature
+    * [EAGLE-169] - Dynamic security event correlation in Eagle
+    * [EAGLE-203] - Metrics feature support merge chart
+    * [EAGLE-225] - Create eagle bootstrap scripts for examples 
+    * [EAGLE-226] - Refactor Eagle scripts to avoid heavily depending on Hortonworks Sandbox
+    * [EAGLE-232] - Create local Kafka/Zookeeper/Storm runner tools for quickstart examples and add related scripts to start/top zk/kafka
+    * [EAGLE-238] - Support scheduling topology in local mode including start/stop/status operations
+    * [EAGLE-266] - Integrate MkDocs for eagle-docs: http://www.mkdocs.org/
+    * [EAGLE-271] - Topology management in remote mode including start/stop/status operations
+    * [EAGLE-272] - Support topology management in UI including creating topology and monitoring status
+    * [EAGLE-282] - Auditlogparser for MapR's audit log 
+    * [EAGLE-284] - Connect to MapR's CLDB service
+    * [EAGLE-298] - Oozie auditlog integration for Oozie security monitoring
+    * [EAGLE-307] - Add applicaiton "maprFSAuditLog" 
+
+** Improvement
+    * [EAGLE-103] - add comments to readme to tell users: currently, eagle is tested under jdk1.7.x, may have compile error with jdk1.8.x
+    * [EAGLE-182] - Replace Legacy "dataSource" field with "application" in UI request
+    * [EAGLE-185] - UI create cache after building
+    * [EAGLE-190] - JBDC Metadata Storage Extension
+    * [EAGLE-193] - UI metric dashboard support sortable
+    * [EAGLE-194] - UI show exception alert if service error
+    * [EAGLE-195] - policy metric display with interval of 5 min or customized interval
+    * [EAGLE-196] - eagle-topology.sh should have jar file path as parameter
+    * [EAGLE-201] - Change maven group name to org.apache.eagle instead of eagle
+    * [EAGLE-205] - Metric dashboard support multi metrics
+    * [EAGLE-207] - Management page add tips
+    * [EAGLE-208] - UI metric dashboard should support order & rename
+    * [EAGLE-216] - Added RM Policy and GC Policies in Resource
+    * [EAGLE-223] - Notification plugin to enable multiple instance of given alert plugin 
+    * [EAGLE-237] - Add development tools for quickly starting zookeeper, kafka and webservice without depending on sandbox
+    * [EAGLE-248] - Rename directories according industrial common sense
+    * [EAGLE-287] - Make EagleStore as the default notification method
+    * [EAGLE-288] - Need to add "Alert De-Dup Interval" setting in "PolicyObjectBase" 
+    * [EAGLE-295] - Add configuration value to enable application Manager
+    * [EAGLE-303] - Refactor message format in the email template.
+    * [EAGLE-305] - Add a config tip to the document for "Application Manager Tutorial" - setting "appCommandLoaderEnabled=true"
+    * [EAGLE-306] - add metadata for showing "Topology" tab in left-nav by default
+    * [EAGLE-315] - Add tutorial for mapr audit log monitoring
+    * [EAGLE-316] - Feature topology should not be added into an application
+    * [EAGLE-339] - Create HBase tables if not exists 
+    * [EAGLE-340] - refactor bin/eagle-sandbox-starter.sh to make it easier to use 
+
+** Bug
+    * [EAGLE-8] - In eagle-check-env.sh shell , Itbad way to check kafka installation
+    * [EAGLE-18] - Follow up with infra about website creation
+    * [EAGLE-157] - policy metric should be refreshed every minute
+    * [EAGLE-171] - Policy listing table is messed up by too long policy name.
+    * [EAGLE-172] - Scripting string is allowed to create policy rules.
+    * [EAGLE-173] - Mark/Un-mark a sensitivity type does not sync status mark in the table list.
+    * [EAGLE-176] - Metric dashboard UI keep api refresh after page switch
+    * [EAGLE-192] - Uncaught ReferenceError: damControllers is not defined (doc.js:7628)
+    * [EAGLE-200] - GC Log Monitoring  Not Working
+    * [EAGLE-210] - UI application group not display correctly
+    * [EAGLE-211] - Fix sometime unit test failing at TestSiddhiStateSnapshotAndRestore
+    * [EAGLE-212] - Fix AlertDataSourceEntity Bug in Hive web
+    * [EAGLE-213] - Updates fail for MySql  
+    * [EAGLE-214] - Policy edit page need auto switch application
+    * [EAGLE-217] - Fix unstable unit tests about state snapshot management
+    * [EAGLE-224] - Column not found to EAGLE_METRIC when using JDBC
+    * [EAGLE-227] - java.lang.NoClassDefFoundError: org/apache/commons/pool/impl/CursorableLinkedList$ListIter
+    * [EAGLE-228] - org.apache.eagle.notification.plugin.NotificationPluginManagerImpl - fail invoking plugin's onAlert, continue  java.lang.NullPointerException: null
+    * [EAGLE-229] - java.lang.IncompatibleClassChangeError: class net.sf.extcos.internal.JavaResourceAccessor$AnnotatedClassVisitor has interface org.objectweb.asm.ClassVisitor as super class
+    * [EAGLE-230] - Exception in persisting entitiesService side exception: org.codehaus.jackson.map.JsonMappingException: Conflicting setter definitions for property "alertContext"
+    * [EAGLE-235] - org.codehaus.jackson.map.JsonMappingException: Conflicting setter definitions for property "alertContext"
+    * [EAGLE-239] - Alert list and details are not correctly displayed
+    * [EAGLE-240] - java.lang.ArrayIndexOutOfBoundsException thrown by MetricKeyCodeDecoder
+    * [EAGLE-242] -  Import the notification plugin metadata when initializing
+    * [EAGLE-254] - HdfsAuditLog topology keeps alerting for one piece of log
+    * [EAGLE-258] - Automatically add apache-github and apache-git in pr tools
+    * [EAGLE-269] - Comparisons between 'LONG VARCHAR (UCS_BASIC)' and 'LONG VARCHAR (UCS_BASIC)' are not supported
+    * [EAGLE-270] - JDBC: Create table fail for some of the tables
+    * [EAGLE-273] -  Issue with creating MySql tables , only 14 were created out of 24, reason being varchar(30000) for multiple columns lead to exceeding the maximum row size of 65,535 bytes.
+    * [EAGLE-274] - 2016-04-15 15:50:20 b.s.d.worker [ERROR] Error on initialization of server mk-worker java.lang.RuntimeException: java.lang.ClassNotFoundException: org.slf4j.impl.Log4jLoggerAdapter
+    * [EAGLE-275] - Eagle email alert bug: $elem["dataSource"] Alert Detected
+    * [EAGLE-291] - JDBC: Update transactions fail in PostgreSQL
+    * [EAGLE-292] - Updated hbase policy failed: Data too long for column 'policyDef' when using mysql storage
+    * [EAGLE-294] - If a policy metadata field is not set, null attributes can not be able to add into input stream for SiddhiCEP 
+    * [EAGLE-297] - Email with authentication can not be validated and sent out.
+    * [EAGLE-300] - Disable spring debug log by default in webservice
+    * [EAGLE-301] - Tables omitted for using mysql
+    * [EAGLE-304] - Enable Advanced dedup configuration in policy definition 
+    * [EAGLE-308] - Consistency issue: deleting a topology doesn't delete existing topology-execution bound to it.
+    * [EAGLE-310] - already existing active topology status not displayed when a deleted topology+execution re-created with same name
+    * [EAGLE-311] - operations of items listed on topology-management monitoring page require buffering loading approaches
+    * [EAGLE-313] - normally stopped topology-execution shows error message in the description column
+    * [EAGLE-319] - java.sql.SQLSyntaxErrorException caught when querying from table topologyExecutionEntity
+    * [EAGLE-321] - java.lang.NoSuchMethodError: com.google.protobuf.LazyStringList.getUnmodifiableView
+    * [EAGLE-326] - typo found in eagle documentation
+    * [EAGLE-327] - java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
+    * [EAGLE-330] - Hive ql.Parser can't parser a hive query sql with keywords
+    * [EAGLE-338] - fix topology-assembly build issue because of module name change
+    * [EAGLE-346] - ClassNotFoundException thrown out when topology is executing
+
+** Task
+    * [EAGLE-73] - Put docker steps to site tutorial
+    * [EAGLE-221] - Support cusomized notification type in policy editor
+    * [EAGLE-222] - Documentation for eagle alert plugin mechnism
+    * [EAGLE-280] - Update logstash-kafka-conf.md
+    * [EAGLE-309] - Add code formatter template
+
+** Sub-task
+    * [EAGLE-219] - Use PUT method for updating request when possible in front-end.

--- a/eagle-assembly/pom.xml
+++ b/eagle-assembly/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -111,7 +111,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptor>src/assembly/eagle-bin.xml</descriptor>
-                    <finalName>eagle-${project.version}</finalName>
+                    <finalName>apache-eagle-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>

--- a/eagle-assembly/src/main/conf/eagle-service.conf
+++ b/eagle-assembly/src/main/conf/eagle-service.conf
@@ -13,18 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-eagle{
-	service{
-		storage-type="hbase"
-		hbase-zookeeper-quorum="sandbox.hortonworks.com"
-		hbase-zookeeper-property-clientPort=2181
-		zookeeper-znode-parent="/hbase-unsecure",
-		springActiveProfile="sandbox"
-		audit-enabled=true
+eagle {
+	service {
+		storage-type="jdbc"
+		storage-adapter="derby"
+		storage-username="eagle"
+		storage-password=eagle
+		storage-database=eagle
+		storage-connection-url="jdbc:derby:/tmp/eagle-db-dev;create=true"
+		storage-connection-props="encoding=UTF-8"
+		storage-driver-class="org.apache.derby.jdbc.EmbeddedDriver"
+		storage-connection-max=8
 	}
 }
-
-
-
-

--- a/eagle-core/eagle-alert/eagle-alert-base/pom.xml
+++ b/eagle-core/eagle-alert/eagle-alert-base/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-alert-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-alert/eagle-alert-notification-plugin/pom.xml
+++ b/eagle-core/eagle-alert/eagle-alert-notification-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-alert-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
   <artifactId>eagle-alert-notification-plugin</artifactId>
   <name>eagle-alert-notification-plugin</name>

--- a/eagle-core/eagle-alert/eagle-alert-process/pom.xml
+++ b/eagle-core/eagle-alert/eagle-alert-process/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-alert-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 	<packaging>jar</packaging>

--- a/eagle-core/eagle-alert/eagle-alert-service/pom.xml
+++ b/eagle-core/eagle-alert/eagle-alert-service/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-alert-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-alert/pom.xml
+++ b/eagle-core/eagle-alert/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-core</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-application-management/eagle-application-service/pom.xml
+++ b/eagle-core/eagle-application-management/eagle-application-service/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>eagle-application-management</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-core/eagle-application-management/eagle-stream-application-manager/pom.xml
+++ b/eagle-core/eagle-application-management/eagle-stream-application-manager/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>eagle-application-management</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-application-management/pom.xml
+++ b/eagle-core/eagle-application-management/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>eagle-core</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-core/eagle-data-process/eagle-job-common/pom.xml
+++ b/eagle-core/eagle-data-process/eagle-job-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-data-process-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>eagle-job-common</artifactId>

--- a/eagle-core/eagle-data-process/eagle-storm-jobrunning-spout/pom.xml
+++ b/eagle-core/eagle-data-process/eagle-storm-jobrunning-spout/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-data-process-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>eagle-storm-jobrunning-spout</artifactId>

--- a/eagle-core/eagle-data-process/eagle-stream-pipeline/pom.xml
+++ b/eagle-core/eagle-data-process/eagle-stream-pipeline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>eagle-data-process-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>eagle-stream-pipeline</artifactId>

--- a/eagle-core/eagle-data-process/eagle-stream-process-api/pom.xml
+++ b/eagle-core/eagle-data-process/eagle-stream-process-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-data-process-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/eagle-core/eagle-data-process/eagle-stream-process-base/pom.xml
+++ b/eagle-core/eagle-data-process/eagle-stream-process-base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-data-process-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/eagle-core/eagle-data-process/pom.xml
+++ b/eagle-core/eagle-data-process/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-core</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <artifactId>eagle-data-process-parent</artifactId>
     <packaging>pom</packaging>

--- a/eagle-core/eagle-embed/eagle-embed-hbase/pom.xml
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-embed-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-embed/eagle-embed-server/pom.xml
+++ b/eagle-core/eagle-embed/eagle-embed-server/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-embed-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>eagle-embed-server</artifactId>

--- a/eagle-core/eagle-embed/pom.xml
+++ b/eagle-core/eagle-embed/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-core</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-machinelearning/eagle-machinelearning-base/pom.xml
+++ b/eagle-core/eagle-machinelearning/eagle-machinelearning-base/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-machinelearning-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>eagle-machinelearning-base</artifactId>

--- a/eagle-core/eagle-machinelearning/pom.xml
+++ b/eagle-core/eagle-machinelearning/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-core</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-metric/pom.xml
+++ b/eagle-core/eagle-metric/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-core</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-policy/eagle-policy-base/pom.xml
+++ b/eagle-core/eagle-policy/eagle-policy-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-policy-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/eagle-core/eagle-policy/pom.xml
+++ b/eagle-core/eagle-policy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-core</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/eagle-core/eagle-query/eagle-antlr/pom.xml
+++ b/eagle-core/eagle-query/eagle-antlr/pom.xml
@@ -21,7 +21,7 @@
   <parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-query-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/eagle-core/eagle-query/eagle-audit-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-audit-base/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-query-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-query/eagle-client-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-client-base/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-query-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-query/eagle-common/pom.xml
+++ b/eagle-core/eagle-query/eagle-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-query-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-query/eagle-entity-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-entity-base/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-query-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-query/eagle-query-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-query-base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-query-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-query/eagle-service-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-service-base/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-query-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/eagle-query/eagle-storage-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-storage-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>eagle-query-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-query/eagle-storage-hbase/pom.xml
+++ b/eagle-core/eagle-query/eagle-storage-hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-query-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-query/eagle-storage-jdbc/pom.xml
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-query-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-core/eagle-query/pom.xml
+++ b/eagle-core/eagle-query/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-core</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-core/pom.xml
+++ b/eagle-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/eagle-examples/eagle-topology-example/pom.xml
+++ b/eagle-examples/eagle-topology-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>eagle-examples</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-examples/pom.xml
+++ b/eagle-examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>eagle-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-external/eagle-kafka/pom.xml
+++ b/eagle-external/eagle-kafka/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>eagle-external-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-external/eagle-log4jkafka/pom.xml
+++ b/eagle-external/eagle-log4jkafka/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-external-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>

--- a/eagle-external/pom.xml
+++ b/eagle-external/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-gc/pom.xml
+++ b/eagle-gc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>eagle-gc</artifactId>

--- a/eagle-hadoop-metric/pom.xml
+++ b/eagle-hadoop-metric/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>eagle-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-security/eagle-metric-collection/pom.xml
+++ b/eagle-security/eagle-metric-collection/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>eagle-metric-collection</artifactId>

--- a/eagle-security/eagle-security-common/pom.xml
+++ b/eagle-security/eagle-security-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
   <artifactId>eagle-security-common</artifactId>
   <name>eagle-security-common</name>

--- a/eagle-security/eagle-security-hbase-securitylog/pom.xml
+++ b/eagle-security/eagle-security-hbase-securitylog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>eagle-security-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-security/eagle-security-hbase-web/pom.xml
+++ b/eagle-security/eagle-security-hbase-web/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>eagle-security-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-security/eagle-security-hdfs-auditlog/pom.xml
+++ b/eagle-security/eagle-security-hdfs-auditlog/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
   <artifactId>eagle-security-hdfs-auditlog</artifactId>
   <packaging>jar</packaging>

--- a/eagle-security/eagle-security-hdfs-securitylog/pom.xml
+++ b/eagle-security/eagle-security-hdfs-securitylog/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>eagle-security-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-security/eagle-security-hdfs-web/pom.xml
+++ b/eagle-security/eagle-security-hdfs-web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
 
   <artifactId>eagle-security-hdfs-web</artifactId>

--- a/eagle-security/eagle-security-hive-web/pom.xml
+++ b/eagle-security/eagle-security-hive-web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
   <artifactId>eagle-security-hive-web</artifactId>
   <name>eagle-security-hive-web</name>

--- a/eagle-security/eagle-security-hive/pom.xml
+++ b/eagle-security/eagle-security-hive/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
   <artifactId>eagle-security-hive</artifactId>
   <name>eagle-security-hive</name>

--- a/eagle-security/eagle-security-maprfs-auditlog/pom.xml
+++ b/eagle-security/eagle-security-maprfs-auditlog/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-security-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <artifactId>eagle-security-maprfs-auditlog</artifactId>
     <packaging>jar</packaging>

--- a/eagle-security/eagle-security-maprfs-web/pom.xml
+++ b/eagle-security/eagle-security-maprfs-web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   </parent>
 
   <artifactId>eagle-security-maprfs-web</artifactId>

--- a/eagle-security/eagle-security-oozie-auditlog/pom.xml
+++ b/eagle-security/eagle-security-oozie-auditlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>eagle-security-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/eagle-security/eagle-security-oozie-web/pom.xml
+++ b/eagle-security/eagle-security-oozie-web/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-security-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <artifactId>eagle-security-oozie-web</artifactId>
     <name>eagle-security-oozie-web</name>

--- a/eagle-security/eagle-security-userprofile/common/pom.xml
+++ b/eagle-security/eagle-security-userprofile/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-userprofile-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/eagle-security/eagle-security-userprofile/detection/pom.xml
+++ b/eagle-security/eagle-security-userprofile/detection/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-security-userprofile-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
   <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>eagle-security-userprofile-detection</artifactId>

--- a/eagle-security/eagle-security-userprofile/pom.xml
+++ b/eagle-security/eagle-security-userprofile/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-security-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/eagle-security/eagle-security-userprofile/training/pom.xml
+++ b/eagle-security/eagle-security-userprofile/training/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>eagle-security-userprofile-parent</artifactId>
         <groupId>org.apache.eagle</groupId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/eagle-security/pom.xml
+++ b/eagle-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>eagle-security-parent</artifactId>

--- a/eagle-topology-assembly/pom.xml
+++ b/eagle-topology-assembly/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.eagle</groupId>
         <artifactId>eagle-parent</artifactId>
-        <version>0.4.0-incubating-SNAPSHOT</version>
+        <version>0.4.0-incubating</version>
     </parent>
     <artifactId>eagle-topology-assembly</artifactId>
     <name>eagle-topology-assembly</name>

--- a/eagle-webservice/pom.xml
+++ b/eagle-webservice/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.apache.eagle</groupId>
 		<artifactId>eagle-parent</artifactId>
-		<version>0.4.0-incubating-SNAPSHOT</version>
+		<version>0.4.0-incubating</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>eagle-webservice</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.apache.eagle</groupId>
     <artifactId>eagle-parent</artifactId>
-    <version>0.4.0-incubating-SNAPSHOT</version>
+    <version>0.4.0-incubating</version>
     <packaging>pom</packaging>
     <name>Apache Eagle Parent</name>
     <url>https://eagle.incubator.apache.org</url>


### PR DESCRIPTION
do the following 2:
1. erase "-SNAPSHOT" suffix from version of modules. 
2. add "apache-" as a prefix of finalName in eagle-assembly/pom.xml, so that final assembled tarball starts with "apache-"