### PR TITLE
EAGLE-358 add help for 404 error on Eagle UI

### DIFF
--- a/eagle-assembly/src/main/README.md
+++ b/eagle-assembly/src/main/README.md
@@ -91,6 +91,9 @@ Sandbox Starter
 		
 * check eagle UI <http://127.0.0.1:9099/eagle-service>
 
+If you get a 404 Error when trying to access the UI, add port 9099 to "Settings->Network->Advanced->Port Forwarding" in VirtualBox.
+(Instruction #4 in https://eagle.incubator.apache.org/docs/quick-start.html)
+
 * Take the following actions which will violate and obey the sample policy.
      * Violation Action: hdfs dfs -ls unknown
      * Violation Action: hdfs dfs -touchz /tmp/private

--- a/eagle-assembly/src/main/README.md
+++ b/eagle-assembly/src/main/README.md
@@ -92,7 +92,7 @@ Sandbox Starter
 * check eagle UI <http://127.0.0.1:9099/eagle-service>
 
 If you get a 404 Error when trying to access the UI, add port 9099 to "Settings->Network->Advanced->Port Forwarding" in VirtualBox.
-(Instruction #4 in https://eagle.incubator.apache.org/docs/quick-start.html)
+(step 4 in "Setup Hadoop Environment" section in https://eagle.incubator.apache.org/docs/quick-start.html)
 
 * Take the following actions which will violate and obey the sample policy.
      * Violation Action: hdfs dfs -ls unknown


### PR DESCRIPTION
I've noticed that some people, including myself, were running into an 404 error when trying to access the Eagle UI after successfully finishing examples/eagle-sandbox-starter.sh

The README.md doesn't explain this but this can be fixed with a simple addition of port 9099 to the virtualbox port forwarding rules (instruction #4 on https://eagle.incubator.apache.org/docs/quick-start.html)

I felt like this should be included/referenced in the final README.md