### PR TITLE
Eagle 376 skip false failing hbase related UT code

### DIFF
--- a/eagle-core/eagle-embed/eagle-embed-hbase/src/test/java/org/apache/eagle/service/hbase/TestHBaseBase.java
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/src/test/java/org/apache/eagle/service/hbase/TestHBaseBase.java
@@ -18,6 +18,7 @@ package org.apache.eagle.service.hbase;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Ignore;
 
 public class TestHBaseBase {
     protected static EmbeddedHbase hbase;
@@ -28,6 +29,7 @@ public class TestHBaseBase {
     }
 
     @Test
+    @Ignore(value="get rid of false failures")
     public void test() {
 
     }

--- a/eagle-core/eagle-query/eagle-entity-base/src/test/java/org/apache/eagle/log/entity/TestGenericEntityIndexStreamReader.java
+++ b/eagle-core/eagle-query/eagle-entity-base/src/test/java/org/apache/eagle/log/entity/TestGenericEntityIndexStreamReader.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+@Ignore(value="get rid of false failures")
 public class TestGenericEntityIndexStreamReader extends TestHBaseBase {
 
 	@Test

--- a/eagle-core/eagle-query/eagle-entity-base/src/test/java/org/apache/eagle/log/entity/TestHBaseWriteEntitiesPerformance.java
+++ b/eagle-core/eagle-query/eagle-entity-base/src/test/java/org/apache/eagle/log/entity/TestHBaseWriteEntitiesPerformance.java
@@ -20,11 +20,8 @@ import org.apache.eagle.log.entity.meta.EntityDefinition;
 import org.apache.eagle.log.entity.meta.EntityDefinitionManager;
 import org.apache.eagle.log.entity.test.TestLogAPIEntity;
 import org.apache.eagle.service.hbase.TestHBaseBase;
-import org.junit.Assert;
+import org.junit.*;
 import org.apache.commons.lang.time.StopWatch;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +31,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
+@Ignore(value="get rid of false failures")
 public class TestHBaseWriteEntitiesPerformance extends TestHBaseBase {
 	private EntityDefinition ed;
 	private final static Logger LOG = LoggerFactory.getLogger(TestHBaseWriteEntitiesPerformance.class);

--- a/eagle-core/eagle-query/eagle-entity-base/src/test/java/org/apache/eagle/log/entity/TestTestLogAPIEntity.java
+++ b/eagle-core/eagle-query/eagle-entity-base/src/test/java/org/apache/eagle/log/entity/TestTestLogAPIEntity.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+@Ignore(value="get rid of false failures")
 public class TestTestLogAPIEntity extends TestHBaseBase {
 
 	@Test 


### PR DESCRIPTION
These faulty UT cases constantly failed because the embeded hbase environment cannot be started up properly, thus they have produced many false failures for long and wasted a lot of building time. Now skip them so that the normal UT cases can expose true issues if there is any.