### PR TITLE
EAGLE-441 AppConfig will override EnvConfig and EnvConfig is default config

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationContext.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationContext.java
@@ -52,18 +52,17 @@ public class ApplicationContext implements Serializable, ApplicationLifecycle {
      * @param metadata ApplicationEntity
      * @param application Application
      */
-    public ApplicationContext(Application application, ApplicationEntity metadata, Config config1){
+    public ApplicationContext(Application application, ApplicationEntity metadata, Config envConfig){
         Preconditions.checkNotNull(application,"Application is null");
         Preconditions.checkNotNull(metadata,"ApplicationEntity is null");
         this.application = application;
         this.metadata = metadata;
-        this.runtime = ExecutionRuntimeManager.getInstance().getRuntime(application.getEnvironmentType(),config1);
+        this.runtime = ExecutionRuntimeManager.getInstance().getRuntime(application.getEnvironmentType(),envConfig);
         Map<String,Object> applicationConfig = metadata.getConfiguration();
         if(applicationConfig == null) {
             applicationConfig = Collections.emptyMap();
         }
-        // TODO: Merge application config with environment config
-        this.config = ConfigFactory.parseMap(applicationConfig);
+        this.config = ConfigFactory.parseMap(applicationConfig).withFallback(envConfig);
     }
 
     @Override

--- a/eagle-core/eagle-app/eagle-app-base/src/test/java/org/apache/eagle/app/service/ApplicationContextTest.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/test/java/org/apache/eagle/app/service/ApplicationContextTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.app.service;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class ApplicationContextTest {
+    /**
+     * appConfig.withFallback(envConfig): appConfig will override envConfig, envConfig is used as default config
+     */
+    @Test
+    public void testTypeSafeConfigMerge(){
+        Config appConfig = ConfigFactory.parseMap(new HashMap<String,String>(){{
+            put("APP_CONFIG",ApplicationContextTest.this.getClass().getCanonicalName());
+            put("SCOPE","APP");
+        }});
+
+        Config envConfig = ConfigFactory.parseMap(new HashMap<String,String>(){{
+            put("ENV_CONFIG",ApplicationContextTest.this.getClass().getCanonicalName());
+            put("SCOPE","ENV");
+        }});
+
+        Config mergedConfig = appConfig.withFallback(envConfig);
+        Assert.assertTrue(mergedConfig.hasPath("APP_CONFIG"));
+        Assert.assertTrue(mergedConfig.hasPath("ENV_CONFIG"));
+        Assert.assertEquals("appConfig.withFallback(envConfig): appConfig will override envConfig, envConfig is used as default config",
+                "APP",mergedConfig.getString("SCOPE"));
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-441

~~~
application config = ConfigFactory.parseMap(applicationConfig).withFallback(envConfig);
~~~