### PR TITLE
EAGLE-453 Use META-INF/providers/${appProviderClassName}.xml as default metadata path

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/spi/AbstractApplicationProvider.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/spi/AbstractApplicationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -31,11 +31,28 @@ import org.slf4j.LoggerFactory;
 import javax.xml.bind.JAXBException;
 import java.util.List;
 
+/**
+ * Default metadata path is:  /META-INF/providers/${ApplicationProviderClassName}.xml
+ *
+ * @param <T>
+ */
 public abstract class AbstractApplicationProvider<T extends Application> implements ApplicationProvider<T> {
     private final static Logger LOG = LoggerFactory.getLogger(AbstractApplicationProvider.class);
     private final ApplicationDesc applicationDesc;
 
-    protected abstract String getMetadata();
+    private final static String METADATA_RESOURCE_PATH="/META-INF/providers/%s.xml";
+
+    /**
+     * Default metadata path is:  /META-INF/providers/${ApplicationProviderClassName}.xml
+     *
+     * You are not recommended to override this method except you could make sure the path is universal unique
+     *
+     * @return metadata file path
+     */
+    protected final String getMetadata(){
+        return String.format(METADATA_RESOURCE_PATH,this.getClass().getName());
+    }
+
     protected AbstractApplicationProvider() {
         String applicationDescConfig = getMetadata();
         applicationDesc = new ApplicationDesc();

--- a/eagle-core/eagle-app/eagle-app-base/src/test/java/org/apache/eagle/app/TestStormApplication.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/test/java/org/apache/eagle/app/TestStormApplication.java
@@ -67,11 +67,6 @@ public class TestStormApplication extends StormApplication{
 
     public final static class Provider extends AbstractApplicationProvider<TestStormApplication> {
         @Override
-        protected String getMetadata() {
-            return "TestApplicationMetadata.xml";
-        }
-
-        @Override
         public TestStormApplication getApplication() {
             return new TestStormApplication();
         }

--- a/eagle-core/eagle-app/eagle-app-base/src/test/resources/META-INF/providers/org.apache.eagle.app.TestStormApplication$Provider.xml
+++ b/eagle-core/eagle-app/eagle-app-base/src/test/resources/META-INF/providers/org.apache.eagle.app.TestStormApplication$Provider.xml
@@ -78,34 +78,34 @@
     </streams>
     <docs>
         <install>
-# Step 1: Create source kafka topic named "${site}_example_source_topic"
+            # Step 1: Create source kafka topic named "${site}_example_source_topic"
 
-./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
+            ./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
 
-# Step 2: Set up data collector to flow data into kafka topic in
+            # Step 2: Set up data collector to flow data into kafka topic in
 
-./bin/logstash -f log_collector.conf
+            ./bin/logstash -f log_collector.conf
 
-## `log_collector.conf` sample as following:
+            ## `log_collector.conf` sample as following:
 
-input {
+            input {
 
-}
-filter {
+            }
+            filter {
 
-}
-output{
+            }
+            output{
 
-}
+            }
 
-# Step 3: start application
+            # Step 3: start application
 
-# Step 4: monitor with featured portal or alert with policies
+            # Step 4: monitor with featured portal or alert with policies
         </install>
         <uninstall>
-# Step 1: stop and uninstall application
-# Step 2: delete kafka topic named "${site}_example_source_topic"
-# Step 3: stop logstash
+            # Step 1: stop and uninstall application
+            # Step 2: delete kafka topic named "${site}_example_source_topic"
+            # Step 3: stop logstash
         </uninstall>
     </docs>
 </application>

--- a/eagle-examples/eagle-app-example/src/main/java/org/apache/eagle/app/example/ExampleApplicationProvider.java
+++ b/eagle-examples/eagle-app-example/src/main/java/org/apache/eagle/app/example/ExampleApplicationProvider.java
@@ -33,10 +33,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ExampleApplicationProvider extends AbstractApplicationProvider<ExampleStormApplication> {
     private final static Logger LOGGER = LoggerFactory.getLogger(ExampleApplicationProvider.class);
-    @Override
-    protected String getMetadata() {
-        return "/META-INF/apps/example/metadata.xml";
-    }
 
     @Override
     public ExampleStormApplication getApplication() {

--- a/eagle-examples/eagle-app-example/src/main/resources/META-INF/providers/org.apache.eagle.app.example.ExampleApplicationProvider.xml
+++ b/eagle-examples/eagle-app-example/src/main/resources/META-INF/providers/org.apache.eagle.app.example.ExampleApplicationProvider.xml
@@ -76,34 +76,34 @@
     </streams>
     <docs>
         <install>
-# Step 1: Create source kafka topic named "${site}_example_source_topic"
+            # Step 1: Create source kafka topic named "${site}_example_source_topic"
 
-./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
+            ./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
 
-# Step 2: Set up data collector to flow data into kafka topic in
+            # Step 2: Set up data collector to flow data into kafka topic in
 
-./bin/logstash -f log_collector.conf
+            ./bin/logstash -f log_collector.conf
 
-## `log_collector.conf` sample as following:
+            ## `log_collector.conf` sample as following:
 
-input {
+            input {
 
-}
-filter {
+            }
+            filter {
 
-}
-output{
+            }
+            output{
 
-}
+            }
 
-# Step 3: start application
+            # Step 3: start application
 
-# Step 4: monitor with featured portal or alert with policies
+            # Step 4: monitor with featured portal or alert with policies
         </install>
         <uninstall>
-# Step 1: stop and uninstall application
-# Step 2: delete kafka topic named "${site}_example_source_topic"
-# Step 3: stop logstash
+            # Step 1: stop and uninstall application
+            # Step 2: delete kafka topic named "${site}_example_source_topic"
+            # Step 3: stop logstash
         </uninstall>
     </docs>
 </application>

--- a/eagle-jpm/eagle-jpm-app/src/main/java/org/apache/eagle/app/jpm/JPMApplicationProvider.java
+++ b/eagle-jpm/eagle-jpm-app/src/main/java/org/apache/eagle/app/jpm/JPMApplicationProvider.java
@@ -23,11 +23,6 @@ import org.apache.eagle.app.spi.AbstractApplicationProvider;
  */
 public class JPMApplicationProvider extends AbstractApplicationProvider<JPMApplication> {
     @Override
-    protected String getMetadata() {
-        return "/META-INF/apps/jpm/metadata.xml";
-    }
-
-    @Override
     public JPMApplication getApplication() {
         return new JPMApplication();
     }

--- a/eagle-jpm/eagle-jpm-app/src/main/resources/META-INF/providers/org.apache.eagle.app.jpm.JPMApplicationProvider.xml
+++ b/eagle-jpm/eagle-jpm-app/src/main/resources/META-INF/providers/org.apache.eagle.app.jpm.JPMApplicationProvider.xml
@@ -76,34 +76,34 @@
     </streams>
     <docs>
         <install>
-# Step 1: Create source kafka topic named "${site}_example_source_topic"
+            # Step 1: Create source kafka topic named "${site}_example_source_topic"
 
-./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
+            ./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
 
-# Step 2: Set up data collector to flow data into kafka topic in
+            # Step 2: Set up data collector to flow data into kafka topic in
 
-./bin/logstash -f log_collector.conf
+            ./bin/logstash -f log_collector.conf
 
-## `log_collector.conf` sample as following:
+            ## `log_collector.conf` sample as following:
 
-input {
+            input {
 
-}
-filter {
+            }
+            filter {
 
-}
-output{
+            }
+            output{
 
-}
+            }
 
-# Step 3: start application
+            # Step 3: start application
 
-# Step 4: monitor with featured portal or alert with policies
+            # Step 4: monitor with featured portal or alert with policies
         </install>
         <uninstall>
-# Step 1: stop and uninstall application
-# Step 2: delete kafka topic named "${site}_example_source_topic"
-# Step 3: stop logstash
+            # Step 1: stop and uninstall application
+            # Step 2: delete kafka topic named "${site}_example_source_topic"
+            # Step 3: stop logstash
         </uninstall>
     </docs>
 </application>

--- a/eagle-security/eagle-security-hbase-auditlog/src/main/java/org/apache/eagle/security/hbase/HBaseAuditLogAppProvider.java
+++ b/eagle-security/eagle-security-hbase-auditlog/src/main/java/org/apache/eagle/security/hbase/HBaseAuditLogAppProvider.java
@@ -33,11 +33,6 @@ import org.apache.eagle.security.service.JDBCSecurityMetadataDAO;
  */
 public class HBaseAuditLogAppProvider extends AbstractApplicationProvider<HBaseAuditLogApplication> {
     @Override
-    protected String getMetadata() {
-        return "/META-INF/metadata.xml";
-    }
-
-    @Override
     public HBaseAuditLogApplication getApplication() {
         return new HBaseAuditLogApplication();
     }

--- a/eagle-security/eagle-security-hbase-auditlog/src/main/resources/META-INF/providers/org.apache.eagle.security.hbase.HBaseAuditLogAppProvider.xml
+++ b/eagle-security/eagle-security-hbase-auditlog/src/main/resources/META-INF/providers/org.apache.eagle.security.hbase.HBaseAuditLogAppProvider.xml
@@ -228,34 +228,34 @@
     </streams>
     <docs>
         <install>
-# Step 1: Create source kafka topic named "${site}_example_source_topic"
+            # Step 1: Create source kafka topic named "${site}_example_source_topic"
 
-./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
+            ./bin/kafka-topics.sh --create --topic example_source_topic --replication-factor 1 --replication 1
 
-# Step 2: Set up data collector to flow data into kafka topic in
+            # Step 2: Set up data collector to flow data into kafka topic in
 
-./bin/logstash -f log_collector.conf
+            ./bin/logstash -f log_collector.conf
 
-## `log_collector.conf` sample as following:
+            ## `log_collector.conf` sample as following:
 
-input {
+            input {
 
-}
-filter {
+            }
+            filter {
 
-}
-output{
+            }
+            output{
 
-}
+            }
 
-# Step 3: start application
+            # Step 3: start application
 
-# Step 4: monitor with featured portal or alert with policies
+            # Step 4: monitor with featured portal or alert with policies
         </install>
         <uninstall>
-# Step 1: stop and uninstall application
-# Step 2: delete kafka topic named "${site}_example_source_topic"
-# Step 3: stop logstash
+            # Step 1: stop and uninstall application
+            # Step 2: delete kafka topic named "${site}_example_source_topic"
+            # Step 3: stop logstash
         </uninstall>
     </docs>
 </application>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-453

Use 

    META-INF/providers/${APP_PROVDER_CLASS_NAME}.xml

as default metadata xml path convention, for example: 

    META-INF/providers/org.apache.eagle.security.hbase.HBaseAuditLogAppProvider.xml

as which is physically universal unique and make app developer's life simpler.