### PR TITLE
EAGLE-411 Refactor hbase related unit test cases with mockito and min…

### DIFF
--- a/eagle-core/eagle-embed/eagle-embed-hbase/src/main/java/org/apache/eagle/service/hbase/EmbeddedHbase.java
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/src/main/java/org/apache/eagle/service/hbase/EmbeddedHbase.java
@@ -65,14 +65,12 @@ public class EmbeddedHbase {
 	    	util = new HBaseTestingUtility();
 	        Configuration conf= util.getConfiguration();
 	        conf.setInt("test.hbase.zookeeper.property.clientPort", port);
-	        conf.set("zookeeper.znode.parent", znode);
 	        conf.setInt("hbase.zookeeper.property.maxClientCnxns", 200);
-			conf.set("hbase.master.ipc.address", "localhost");
 	        conf.setInt("hbase.master.info.port", -1);//avoid port clobbering
 	        // start mini hbase cluster
 	        hBaseCluster = util.startMiniCluster();
 	        Configuration config = hBaseCluster.getConf();
-	        
+
 	        config.set("zookeeper.session.timeout", "120000");
 	        config.set("hbase.zookeeper.property.tickTime", "6000");
 	        config.set(HConstants.HBASE_CLIENT_PAUSE, "3000");


### PR DESCRIPTION
- Delete "zookeeper.znode.parent" and "hbase.master.ipc.address" in HbaseTestingUtility configuration.
- Support the Hbase UT which based the class to pass in meanful time

https://issues.apache.org/jira/browse/EAGLE-411