### PR TITLE
EAGLE-411 Refactor hbase related unit test cases with mockito

### DIFF
--- a/eagle-core/eagle-query/eagle-service-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-service-base/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>eagle-service-base</artifactId>
     <packaging>jar</packaging>
     <name>eagle-service-base</name>
+    <properties>
+        <powermock.version>1.6.5</powermock.version>
+        <powermock-api-mockito.version>1.6.5</powermock-api-mockito.version>
+    </properties>
 
     <dependencies>
         <!-- put eagle-storage-base dependency at the top for using asm 4.0 jar !-->
@@ -73,5 +77,18 @@
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock-api-mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestHBaseLogReader2.java
+++ b/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestHBaseLogReader2.java
@@ -15,77 +15,105 @@
  * limitations under the License.
  */
 package org.apache.eagle.service.generic;
-
 import org.apache.eagle.common.ByteUtil;
 import org.apache.eagle.common.DateTimeUtil;
-import org.apache.eagle.log.entity.GenericEntityBatchReader;
-import org.apache.eagle.log.entity.GenericEntityWriter;
-import org.apache.eagle.log.entity.SearchCondition;
+import org.apache.eagle.common.config.EagleConfigConstants;
+import org.apache.eagle.common.config.EagleConfigFactory;
+import org.apache.eagle.log.entity.*;
 import org.apache.eagle.log.entity.meta.EntityDefinition;
 import org.apache.eagle.log.entity.meta.EntityDefinitionManager;
 import org.apache.eagle.log.entity.test.TestTimeSeriesAPIEntity;
 import org.apache.eagle.query.ListQueryCompiler;
-import org.apache.eagle.service.hbase.EmbeddedHbase;
+import org.apache.hadoop.hbase.*;
+import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.*;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 
-@Ignore
+@RunWith(MockitoJUnitRunner.class)
 public class TestHBaseLogReader2 {
 	private final static Logger LOG = LoggerFactory.getLogger(TestHBaseLogReader2.class);
-    private static EmbeddedHbase hbase = EmbeddedHbase.getInstance();
-	
+	@Mock
+	private static HBaseTestingUtility hBaseTestingUtility;
+	@Mock
+	private static EagleConfigFactory eagleConfigFactory;
+	@Mock
+	private static HTable hTable;
+	@Mock
+	private static ResultScanner resultScanner;
+	private Queue<Result> queue;
+	private static Result result1;
+	private static Result result2;
+	private static long timestamp1;
+	private static long timestamp2;
+	private final static String cluster = "cluster1";
+	private final static String datacenter = "dc1";
+	private static String serviceName;
+	private static EntityDefinition entityDefinition;
+
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		entityDefinition = EntityDefinitionManager.getEntityDefinitionByEntityClass(TestTimeSeriesAPIEntity.class);
+		EntityDefinitionManager.registerEntity(TestTimeSeriesAPIEntity.class);
+		serviceName = "TestTimeSeriesAPIEntity";
+
+		TestTimeSeriesAPIEntity entityA = new TestTimeSeriesAPIEntity();
+		timestamp1 = DateTimeUtil.humanDateToSeconds("2014-04-08 03:00:00") * 1000;
+		LOG.info("First entity timestamp:" + timestamp1);
+		entityA.setTimestamp(timestamp1);
+		entityA.setTags(new HashMap<String, String>() {{
+			put("cluster", cluster);
+			put("datacenter", datacenter);
+		}});
+		entityA.setField7("field7");
+
+		TestTimeSeriesAPIEntity entityB = new TestTimeSeriesAPIEntity();
+		timestamp2 = DateTimeUtil.humanDateToSeconds("2014-05-08 04:00:00") * 1000;
+		LOG.info("Second entity timestamp:" + timestamp2);
+		entityB.setTimestamp(timestamp2);
+		entityB.setTags(new HashMap<String, String>() {{
+			put("cluster", cluster);
+			put("datacenter", datacenter);
+		}});
+		entityB.setField7("field7_2");
+
+		List<Cell> cellsList1 = new ArrayList<>();
+		Cell cell1 = CellUtil.createCell(generateRow(entityA, entityDefinition), Bytes.toBytes(entityDefinition.getColumnFamily()), Bytes.toBytes("g"), System.currentTimeMillis(), KeyValue.Type.Put.getCode(), Bytes.toBytes("field7"));
+		cellsList1.add(cell1);
+		result1 = Result.create(cellsList1);
+
+		List<Cell> cellsList2 = new ArrayList<>();
+		Cell cell2 = CellUtil.createCell(generateRow(entityB, entityDefinition), Bytes.toBytes(entityDefinition.getColumnFamily()), Bytes.toBytes("g"), System.currentTimeMillis(), KeyValue.Type.Put.getCode(), Bytes.toBytes("field7_2"));
+		cellsList2.add(cell2);
+		result2 = Result.create(cellsList2);
+	}
+
 	@SuppressWarnings("serial")
 	@Test
-	public void testStartTimeInclusiveEndTimeExclusive() throws IOException, IllegalAccessException, InstantiationException {
-		EntityDefinition entityDefinition = EntityDefinitionManager.getEntityDefinitionByEntityClass(TestTimeSeriesAPIEntity.class);
-		hbase.createTable(entityDefinition.getTable(), entityDefinition.getColumnFamily());
+	public void testStartTimeInclusiveEndTimeExclusive() throws Exception, IllegalAccessException, InstantiationException {
+		Whitebox.setInternalState(EagleConfigFactory.class, "manager", eagleConfigFactory);
+		PowerMockito.when(eagleConfigFactory.getHTable(Mockito.any(String.class))).thenReturn(hTable);
+		PowerMockito.when(eagleConfigFactory.getTimeZone()).thenReturn(TimeZone.getTimeZone(EagleConfigConstants.DEFAULT_EAGLE_TIME_ZONE));
+		PowerMockito.when(hTable.getScanner(Mockito.any(Scan.class))).thenReturn(resultScanner);
 
-		EntityDefinitionManager.registerEntity(TestTimeSeriesAPIEntity.class);
-		try{
-			final String cluster = "cluster1";
-			final String datacenter = "dc1";
-			String serviceName = "TestTimeSeriesAPIEntity";
-			GenericEntityWriter writer = new GenericEntityWriter(serviceName);
-			List<TestTimeSeriesAPIEntity> entities = new ArrayList<TestTimeSeriesAPIEntity>();
-			TestTimeSeriesAPIEntity entity = new TestTimeSeriesAPIEntity();
-			long timestamp1 = DateTimeUtil.humanDateToSeconds("2014-04-08 03:00:00")*1000;
-			LOG.info("First entity timestamp:" + timestamp1);
-			entity.setTimestamp(timestamp1);
-			entity.setTags(new HashMap<String, String>(){{
-				put("cluster", cluster);
-				put("datacenter", datacenter);
-			}});
-			entity.setField7("field7");
-			entities.add(entity);
-			
-			entity = new TestTimeSeriesAPIEntity();
-			long timestamp2 = DateTimeUtil.humanDateToSeconds("2014-05-08 04:00:00")*1000;
-			LOG.info("Second entity timestamp:" + timestamp2);
-			entity.setTimestamp(timestamp2);
-			entity.setTags(new HashMap<String, String>(){{
-				put("cluster", cluster);
-				put("datacenter", datacenter);
-			}});
-			entity.setField7("field7_2");
-			entities.add(entity);
-			writer.write(entities);
-
-			// for timezone difference between UTC & localtime, enlarge the search range
-			long queryStartTimestamp = timestamp1-24*60*60*1000;
-			long queryEndTimestamp = timestamp1+24*60*60*1000;
+		try {
+			queue = new LinkedList<>();
+			queue.add(result1);
+			PowerMockito.when(resultScanner.next()).thenReturn(queue.poll(), null);
+			long queryStartTimestamp = timestamp1 - 24 * 60 * 60 * 1000;
+			long queryEndTimestamp = timestamp1 + 24 * 60 * 60 * 1000;
 			LOG.info("Query start timestamp:" + queryStartTimestamp);
 			LOG.info("Query end  timestamp:" + queryEndTimestamp);
-			
 			String format = "%s[@cluster=\"%s\" AND @datacenter=\"%s\"]{%s}";
 			String query = String.format(format, serviceName, cluster, datacenter, "@field7");
 			ListQueryCompiler comp = new ListQueryCompiler(query);
@@ -93,47 +121,59 @@ public class TestHBaseLogReader2 {
 			condition.setFilter(comp.filter());
 			condition.setQueryExpression(comp.getQueryExpression());
 			condition.setOutputFields(comp.outputFields());
-			
 			final List<String[]> partitionValues = comp.getQueryPartitionValues();
 			if (partitionValues != null) {
 				condition.setPartitionValues(Arrays.asList(partitionValues.get(0)));
 			}
-
 			condition.setStartRowkey(null);
 			condition.setPageSize(Integer.MAX_VALUE);
 			condition.setStartTime(DateTimeUtil.millisecondsToHumanDateWithSeconds(0));
 			condition.setEndTime(DateTimeUtil.millisecondsToHumanDateWithSeconds(queryEndTimestamp));
-			
-			GenericEntityBatchReader reader = new GenericEntityBatchReader(serviceName, condition); 
+			GenericEntityBatchReader reader = new GenericEntityBatchReader(serviceName, condition);
 			List<TestTimeSeriesAPIEntity> list = reader.read();
-
 			Assert.assertEquals(1, list.size());
-			Assert.assertEquals(timestamp1, list.get(0).getTimestamp());
 			Assert.assertEquals("field7", list.get(0).getField7());
+			Assert.assertEquals(timestamp1, list.get(0).getTimestamp());
 
+
+			queue = new LinkedList<>();
+			queue.add(result1);
+			queue.add(result2);
+			PowerMockito.when(resultScanner.next()).thenReturn(queue.poll(), queue.poll(), null);
 			// for timezone difference between UTC & localtime, enlarge the search range
-			queryStartTimestamp = timestamp1-24*60*60*1000;
-			queryEndTimestamp = timestamp2+24*60*60*1000;  // eagle timestamp is rounded to seconds
+			queryStartTimestamp = timestamp1 - 24 * 60 * 60 * 1000;
+			queryEndTimestamp = timestamp2 + 24 * 60 * 60 * 1000;  // eagle timestamp is rounded to seconds
 			condition.setStartTime(DateTimeUtil.millisecondsToHumanDateWithSeconds(queryStartTimestamp));
 			condition.setEndTime(DateTimeUtil.millisecondsToHumanDateWithSeconds(queryEndTimestamp));
-			reader = new GenericEntityBatchReader(serviceName, condition); 
+			reader = new GenericEntityBatchReader(serviceName, condition);
 			list = reader.read();
 			Assert.assertEquals(2, list.size());
-			
+
+			PowerMockito.when(resultScanner.next()).thenReturn(null);
 			queryStartTimestamp = timestamp1;
 			queryEndTimestamp = timestamp1;  // eagle timestamp is rounded to seconds
 			condition.setStartTime(DateTimeUtil.millisecondsToHumanDateWithSeconds(queryStartTimestamp));
 			condition.setEndTime(DateTimeUtil.millisecondsToHumanDateWithSeconds(queryEndTimestamp));
-			reader = new GenericEntityBatchReader(serviceName, condition); 
+			reader = new GenericEntityBatchReader(serviceName, condition);
 			list = reader.read();
 			Assert.assertEquals(0, list.size());
-			hbase.deleteTable(entityDefinition.getTable());
-		}catch(Exception ex){
+
+
+		} catch (Exception ex) {
 			LOG.error("error", ex);
 			Assert.fail();
+		} finally {
+			hBaseTestingUtility.deleteTable(hTable.getTableName());
+
 		}
+
 	}
-	
+
+	private static byte[] generateRow(TestTimeSeriesAPIEntity entity, EntityDefinition entityDefinition) throws Exception {
+		InternalLog entityLog = HBaseInternalLogHelper.convertToInternalLog(entity, entityDefinition);
+		return RowkeyBuilder.buildRowkey(entityLog);
+	}
+
 	@Test
 	public void testByteComparison(){
 		byte[] byte1 = new byte[]{-23, 12, 63};
@@ -144,7 +184,7 @@ public class TestHBaseLogReader2 {
 		byte[] byte4 = ByteUtil.concat(byte1, new byte[]{-128});
 		Assert.assertTrue(Bytes.compareTo(byte4, byte3) > 0);
 	}
-	
+
 	@Test
 	public void testMaxByteInBytesComparision(){
 		int max = -1000000;
@@ -157,7 +197,7 @@ public class TestHBaseLogReader2 {
 			max = Math.max(max, tmp);
 		}
 		System.out.println(max);
-		
+
 		byte b = -1;
 		System.out.println(b & 0xff);
 	}


### PR DESCRIPTION
EAGLE-411 Refactor hbase related unit test cases with mockito
- Mock the action of HBase reading, mock the meanful result of scanner.next(), unit test would not be enslaved to HBase.

https://issues.apache.org/jira/browse/EAGLE-411.