### PR TITLE
EAGLE-498 overwrite equals method for PolicyDefinition should not con…

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PolicyDefinition.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PolicyDefinition.java
@@ -127,7 +127,6 @@ public class PolicyDefinition implements Serializable{
     public int hashCode() {
         return new HashCodeBuilder().
                 append(name).
-//                append(description).
                 append(inputStreams).
                 append(outputStreams).
                 append(definition).
@@ -144,7 +143,6 @@ public class PolicyDefinition implements Serializable{
             return false;
         PolicyDefinition another = (PolicyDefinition)that;
         if(another.name.equals(this.name) &&
-//                another.description.equals(this.description) &&
                 CollectionUtils.isEqualCollection(another.inputStreams, this.inputStreams) &&
                 CollectionUtils.isEqualCollection(another.outputStreams, this.outputStreams) &&
                 another.definition.equals(this.definition) &&

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PolicyDefinition.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PolicyDefinition.java
@@ -127,7 +127,7 @@ public class PolicyDefinition implements Serializable{
     public int hashCode() {
         return new HashCodeBuilder().
                 append(name).
-                append(description).
+//                append(description).
                 append(inputStreams).
                 append(outputStreams).
                 append(definition).
@@ -144,7 +144,7 @@ public class PolicyDefinition implements Serializable{
             return false;
         PolicyDefinition another = (PolicyDefinition)that;
         if(another.name.equals(this.name) &&
-                another.description.equals(this.description) &&
+//                another.description.equals(this.description) &&
                 CollectionUtils.isEqualCollection(another.inputStreams, this.inputStreams) &&
                 CollectionUtils.isEqualCollection(another.outputStreams, this.outputStreams) &&
                 another.definition.equals(this.definition) &&


### PR DESCRIPTION
EAGLE-498 overwrite equals method for PolicyDefinition should not contain field description

- Delete the equals for description in method equals.
- Delete append description in method hashCode.

https://issues.apache.org/jira/browse/EAGLE-498