### PR TITLE
[EAGLE-539] add failure category and job count by state to mr feeder

### DIFF
--- a/eagle-jpm/eagle-jpm-entity/src/main/java/org/apache/eagle/jpm/mr/historyentity/JobExecutionAPIEntity.java
+++ b/eagle-jpm/eagle-jpm-entity/src/main/java/org/apache/eagle/jpm/mr/historyentity/JobExecutionAPIEntity.java
@@ -23,6 +23,8 @@ import org.apache.eagle.jpm.util.jobcounter.JobCounters;
 import org.apache.eagle.log.entity.meta.*;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
+import java.util.Map;
+
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @Table("eaglejpa")
 @ColumnFamily("f")
@@ -91,6 +93,8 @@ public class JobExecutionAPIEntity extends JobBaseAPIEntity {
     private int failedReduceAttempts;
     @Column("ad")
     private String trackingUrl;
+    @Column("ae")
+    private Map<String, Map<String, String>> failedTasks;
 
     public String getTrackingUrl() {
         return trackingUrl;
@@ -342,5 +346,14 @@ public class JobExecutionAPIEntity extends JobBaseAPIEntity {
     public void setFailedReduceAttempts(int failedReduceAttempts) {
         this.failedReduceAttempts = failedReduceAttempts;
         valueChanged("failedReduceAttempts");
+    }
+
+    public Map<String, Map<String, String>> getFailedTasks() {
+        return failedTasks;
+    }
+
+    public void setFailedTasks(Map<String, Map<String, String>> failedTasks) {
+        this.failedTasks = failedTasks;
+        valueChanged("failedTasks");
     }
 }

--- a/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/metrics/JobExecutionMetricsCreationListener.java
+++ b/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/metrics/JobExecutionMetricsCreationListener.java
@@ -20,10 +20,12 @@ package org.apache.eagle.jpm.mr.history.metrics;
 
 import org.apache.eagle.jpm.mr.historyentity.JobExecutionAPIEntity;
 import org.apache.eagle.jpm.util.Constants;
+import org.apache.eagle.jpm.util.MRJobTagName;
 import org.apache.eagle.jpm.util.metrics.AbstractMetricsCreationListener;
 import org.apache.eagle.log.entity.GenericMetricEntity;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,6 +63,14 @@ public class JobExecutionMetricsCreationListener extends AbstractMetricsCreation
                     }
                 }
             }
+
+            //generate Constants.JOB_COUNT_PER_HOUR data
+            Map<String, String> baseTags = new HashMap<>(tags);
+            baseTags.put(MRJobTagName.JOB_STATUS.toString(), entity.getCurrentState());
+            metrics.add(metricWrapper(timeStamp / 3600000 * 3600000,
+                Constants.JOB_COUNT_PER_HOUR,
+                new double[]{1},
+                baseTags));
         }
         return metrics;
     }

--- a/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/parser/TaskFailureListener.java
+++ b/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/parser/TaskFailureListener.java
@@ -93,6 +93,7 @@ public class TaskFailureListener implements HistoryJobEntityCreationListener {
         //TODO need optimize, match and then capture the data
         final String errCategory = classifier.classifyError(e.getError());
         tags.put(MRJobTagName.ERROR_CATEGORY.toString(), errCategory);
+        entity.getTags().put(MRJobTagName.ERROR_CATEGORY.toString(), errCategory);
 
         failureTask.setError(e.getError());
         failureTask.setFailureCount(1); // hard coded to 1 unless we do pre-aggregation in the future

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobParser.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobParser.java
@@ -452,7 +452,7 @@ public class MRJobParser implements Runnable {
             Utils.closeInputStream(is);
         }
 
-        Set<String> needFetchAttemptTasks = calcFetchCounterAndAttemptTaskId(tasks);
+        Set<String> needFetchAttemptTasks = new HashSet<>();//calcFetchCounterAndAttemptTaskId(tasks);
         for (MRTask task : tasks) {
             if (this.finishedTaskIds.contains(task.getId()) && !needFetchAttemptTasks.contains(task.getId())) {
                 continue;
@@ -530,6 +530,7 @@ public class MRJobParser implements Runnable {
                     mrJobEntityMap.get(jobId).getTags().put(MRJobTagName.JOD_DEF_ID.toString(), value);
                 }
             }
+            mrJobEntityMap.get(jobId).getTags().put(MRJobTagName.JOB_TYPE.toString(), Utils.fetchJobType(config).toString());
             mrJobEntityMap.get(jobId).setJobConfig(config);
             mrJobConfigs.put(jobId, config);
 

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/Constants.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/Constants.java
@@ -178,7 +178,8 @@ public class Constants {
     public static final String JOB_LEVEL = "job";
     public static final String TASK_LEVEL = "task";
     public static final String USER_LEVEL = "user";
-    public static final String JOB_COUNT_PER_DAY = "hadoop.job.day.count";
+    public static final String JOB_COUNT_PER_DAY = "day.count";
+    public static final String JOB_COUNT_PER_HOUR = "hour.count";
 
     public static final String HADOOP_HISTORY_TOTAL_METRIC_FORMAT = "hadoop.%s.history.%s";
     public static final String HADOOP_HISTORY_MINUTE_METRIC_FORMAT = "hadoop.%s.history.minute.%s";

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/Utils.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/Utils.java
@@ -18,6 +18,7 @@
 
 package org.apache.eagle.jpm.util;
 
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,9 @@ import java.io.InputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public class Utils {
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
@@ -85,5 +89,27 @@ public class Utils {
         LOG.warn("Cannot parse memory info " +  memory);
 
         return 0L;
+    }
+    
+    public static Constants.JobType fetchJobType(Map config) {
+        if (config.get(Constants.JobConfiguration.CASCADING_JOB) != null) {
+            return Constants.JobType.CASCADING;
+        }
+        if (config.get(Constants.JobConfiguration.HIVE_JOB) != null) {
+            return Constants.JobType.HIVE;
+        }
+        if (config.get(Constants.JobConfiguration.PIG_JOB) != null) {
+            return Constants.JobType.PIG;
+        }
+        if (config.get(Constants.JobConfiguration.SCOOBI_JOB) != null) {
+            return Constants.JobType.SCOOBI;
+        }
+        return Constants.JobType.NOTAVALIABLE;
+    }
+
+    public static Constants.JobType fetchJobType(Configuration config) {
+        Map<String, String> mapConfig = new HashMap<>();
+        config.forEach(entry -> mapConfig.put(entry.getKey(), entry.getValue()));
+        return fetchJobType(mapConfig);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-539

1. We need to classify the errors that generated by mr jobs so that we can analysis requirements like top-n errors or top-n hosts that generate errors. I implement this by using the error messages that generated by the tasks and extract the rules from them.
2. Another requirement is get job count by job status. When we parse jobs in mr history feeder, we can save job id and job status in zookeeper, and then we can flush them to eagle server.