### PR TITLE
EAGLE-549 Add required field for application configuration

### DIFF
--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/Configuration.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/Configuration.java
@@ -36,18 +36,18 @@ public class Configuration {
         return properties;
     }
 
-    public Property getProperty(String name){
-        for(Property property :properties){
-            if(property.getName().equals(name)){
+    public Property getProperty(String name) {
+        for (Property property : properties) {
+            if (property.getName().equals(name)) {
                 return property;
             }
         }
         return null;
     }
 
-    public boolean hasProperty(String name){
-        for(Property property :properties){
-            if(property.getName().equals(name)){
+    public boolean hasProperty(String name) {
+        for (Property property : properties) {
+            if (property.getName().equals(name)) {
                 return true;
             }
         }
@@ -61,12 +61,13 @@ public class Configuration {
     public static Configuration fromResource(String resourceName) throws JAXBException {
         return ConfigTemplateHelper.unmarshallFromResource(resourceName);
     }
+
     public static Configuration fromString(String xmlContent) throws JAXBException {
         return ConfigTemplateHelper.unmarshallFromXMLString(xmlContent);
     }
 
-    public int size(){
-        if(this.properties == null){
+    public int size() {
+        if (this.properties == null) {
             return 0;
         }
         return this.properties.size();

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/Property.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/Property.java
@@ -21,6 +21,7 @@ public class Property {
     private String displayName;
     private String value;
     private String description;
+    private boolean required;
 
     public String getDescription() {
         return description;
@@ -52,5 +53,13 @@ public class Property {
 
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
     }
 }

--- a/eagle-jpm/eagle-jpm-web/src/main/resources/META-INF/providers/org.apache.eagle.app.jpm.JPMWebApplicationProvider.xml
+++ b/eagle-jpm/eagle-jpm-web/src/main/resources/META-INF/providers/org.apache.eagle.app.jpm.JPMWebApplicationProvider.xml
@@ -46,12 +46,14 @@
             <value>localhost</value>
             <displayName>Eagle Service Host</displayName>
             <description>Eagle Service Host, default: localhost</description>
+            <required>true</required>
         </property>
         <property>
             <name>service.port</name>
             <value>8080</value>
             <displayName>Eagle Service Port</displayName>
             <description>Eagle Service Port, default: 8080</description>
+            <required>true</required>
         </property>
     </configuration>
 </application>


### PR DESCRIPTION
Support `required`:`boolean` in configuration property.

~~~
<configuration>
    <property>
        <name>service.host</name>
        <value>localhost</value>
        <displayName>Eagle Service Host</displayName>
        <description>Eagle Service Host, default: localhost</description>
       <required>true</required>
    </property>
</configuration>
~~~