### PR TITLE
Fixed wrongly aggregateCondition.getIntervalMS()

### DIFF
--- a/eagle-core/eagle-query/eagle-storage-hbase/src/main/java/org/apache/eagle/storage/hbase/query/aggregate/GenericInMemoryAggregateQuery.java
+++ b/eagle-core/eagle-query/eagle-storage-hbase/src/main/java/org/apache/eagle/storage/hbase/query/aggregate/GenericInMemoryAggregateQuery.java
@@ -176,7 +176,7 @@ public class GenericInMemoryAggregateQuery implements GenericQuery {
             TimeSeriesAggregator tsAgg = new TimeSeriesAggregator(groupbyFields,
                 aggregateCondition.getAggregateFunctionTypes(), aggregateFields,
                     DateTimeUtil.humanDateToDate(searchCondition.getStartTime()).getTime(),
-                DateTimeUtil.humanDateToDate(searchCondition.getEndTime()).getTime(), aggregateCondition.getIntervalMS() * 60 * 1000);
+                DateTimeUtil.humanDateToDate(searchCondition.getEndTime()).getTime(), aggregateCondition.getIntervalMS());
             reader.register(tsAgg);
 
             // for sorting


### PR DESCRIPTION
## Problem
When querying eagle storage like: 
~~~
http://localhost:9090/rest/entities?query=GenericMetricService[@site=%22sample%22]%3C@site%3E%7Bmax(value)%7D&metricName=hadoop.cluster.totalmemory&pageSize=100000&startTime=2016-09-19%2006:25:00&endTime=2016-09-19%2008:25:00&intervalmin=5&timeSeries=true
~~~
, the expected result should look like:

~~~
{
meta: {
firstTimestamp: 1474273440000,
totalResults: 1,
lastTimestamp: 1474266300000,
elapsedms: 1358
},
success: true,
obj: [
{
key: [
"apollo"
],
value: [
[
203633792,
205067904,
205115648,
205830912,
205980160,
205739392,
205809792,
204790400,
202791040,
202848768,
201649152,
198402176,
198410496,
201081088,
202256128,
203858304,
202554624,
200818304,
203813248,
203441536,
205401472,
206122368,
205884416,
206158976
]
]
}
],
type: "java.util.Map"
}
~~~

,

but actual is:

~~~
{
meta: {
firstTimestamp: 1474273440000,
totalResults: 1,
lastTimestamp: 1474266300000,
elapsedms: 9
},
success: true,
obj: [
{
key: [
"apollo"
],
value: [
[
206158976
]
]
}
],
type: "java.util.Map"
~~~

## Root Cause

Wrongly calculated milliseconds by
~~~
aggregateCondition.getIntervalMS() * 60 * 1000
~~~
should be
~~~
aggregateCondition.getIntervalMS()
~~~