### PR TITLE
[EAGLE-564] pack mr history/running feeder in one topology and bugs fix

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/impl/ApplicationManagementServiceImpl.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/impl/ApplicationManagementServiceImpl.java
@@ -64,9 +64,6 @@ public class ApplicationManagementServiceImpl implements ApplicationManagementSe
     public ApplicationEntity install(ApplicationOperations.InstallOperation operation) throws EntityNotFoundException {
         Preconditions.checkNotNull(operation.getSiteId(), "siteId is null");
         Preconditions.checkNotNull(operation.getAppType(), "appType is null");
-        if (operation.getMode().equals(ApplicationEntity.Mode.CLUSTER)) {
-            Preconditions.checkNotNull(operation.getJarPath(), "jarPath is null when mode is CLUSTER");
-        }
         SiteEntity siteEntity = siteEntityService.getBySiteId(operation.getSiteId());
         Preconditions.checkNotNull(siteEntity, "Site with ID: " + operation.getSiteId() + " is not found");
         ApplicationDesc appDesc = applicationProviderService.getApplicationDescByType(operation.getAppType());
@@ -75,7 +72,7 @@ public class ApplicationManagementServiceImpl implements ApplicationManagementSe
         applicationEntity.setDescriptor(appDesc);
         applicationEntity.setSite(siteEntity);
         applicationEntity.setMode(operation.getMode());
-        applicationEntity.setJarPath(operation.getJarPath());
+        applicationEntity.setJarPath(operation.getJarPath() == null ? appDesc.getJarPath() : operation.getJarPath());
         applicationEntity.ensureDefault();
 
         // Calculate application config based on:

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/spi/ApplicationXMLDescriptorLoader.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/spi/ApplicationXMLDescriptorLoader.java
@@ -18,6 +18,7 @@ package org.apache.eagle.app.spi;
 
 import org.apache.eagle.app.Application;
 import org.apache.eagle.app.config.ApplicationProviderDescConfig;
+import org.apache.eagle.app.utils.DynamicJarPathFinder;
 import org.apache.eagle.metadata.model.ApplicationDesc;
 
 /**
@@ -54,6 +55,7 @@ class ApplicationXMLDescriptorLoader implements ApplicationDescLoader {
         applicationDesc.setVersion(descWrapperConfig.getVersion());
         applicationDesc.setName(descWrapperConfig.getName());
         applicationDesc.setDocs(descWrapperConfig.getDocs());
+        applicationDesc.setJarPath(DynamicJarPathFinder.findPath(applicationClass));
         if (applicationClass != null) {
             applicationDesc.setAppClass(applicationClass);
             if (!Application.class.isAssignableFrom(applicationDesc.getAppClass())) {

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/ApplicationDesc.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/ApplicationDesc.java
@@ -30,6 +30,7 @@ public class ApplicationDesc implements Serializable {
     private String version;
     private String description;
     private Class<?> appClass;
+    private String jarPath;
     private String viewPath;
     private Class<?> providerClass;
     private Configuration configuration;
@@ -50,6 +51,10 @@ public class ApplicationDesc implements Serializable {
         return type;
     }
 
+    public String getJarPath() {
+        return jarPath;
+    }
+
     public Configuration getConfiguration() {
         return configuration;
     }
@@ -64,6 +69,10 @@ public class ApplicationDesc implements Serializable {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public void setJarPath(String jarPath) {
+        this.jarPath = jarPath;
     }
 
     public void setName(String name) {
@@ -100,8 +109,8 @@ public class ApplicationDesc implements Serializable {
 
     @Override
     public String toString() {
-        return String.format("ApplicationDesc [type=%s, name=%s, version=%s, appClass=%s, viewPath=%s, providerClass=%s, configuration= %s properties, description=%s",
-            getType(), getName(), getVersion(), getAppClass(), getViewPath(), getProviderClass(), getConfiguration() == null ? 0 : getConfiguration().size(), getDescription());
+        return String.format("ApplicationDesc [type=%s, name=%s, version=%s, appClass=%s, viewPath=%s, jarpath=%s, providerClass=%s, configuration= %s properties, description=%s",
+            getType(), getName(), getVersion(), getAppClass(), getViewPath(),getJarPath(), getProviderClass(), getConfiguration() == null ? 0 : getConfiguration().size(), getDescription());
     }
 
     public void setConfiguration(Configuration configuration) {

--- a/eagle-core/eagle-query/eagle-query-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-query-base/pom.xml
@@ -39,5 +39,10 @@
             <artifactId>eagle-entity-base</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/MRHistoryJobConfig.java
+++ b/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/MRHistoryJobConfig.java
@@ -37,12 +37,6 @@ public class MRHistoryJobConfig implements Serializable {
 
     private static final String JOB_CONFIGURE_KEY_CONF_FILE = "JobConfigKeys.conf";
 
-    public String getEnv() {
-        return env;
-    }
-
-    private String env;
-
     public ZKStateConfig getZkStateConfig() {
         return zkStateConfig;
     }
@@ -150,7 +144,6 @@ public class MRHistoryJobConfig implements Serializable {
      */
     private void init(Config config) {
         this.config = config;
-        this.env = config.getString("envContextConfig.env");
         //parse eagle job extractor
         this.jobExtractorConfig.site = config.getString("jobExtractorConfig.site");
         this.jobExtractorConfig.mrVersion = config.getString("jobExtractorConfig.mrVersion");
@@ -193,7 +186,6 @@ public class MRHistoryJobConfig implements Serializable {
         this.eagleServiceConfig.password = config.getString("eagleProps.eagleService.password");
 
         LOG.info("Successfully initialized MRHistoryJobConfig");
-        LOG.info("env: " + this.env);
         LOG.info("zookeeper.quorum: " + this.zkStateConfig.zkQuorum);
         LOG.info("zookeeper.property.clientPort: " + this.zkStateConfig.zkPort);
         LOG.info("eagle.service.host: " + this.eagleServiceConfig.eagleServiceHost);

--- a/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/parser/JHFEventReaderBase.java
+++ b/eagle-jpm/eagle-jpm-mr-history/src/main/java/org/apache/eagle/jpm/mr/history/parser/JHFEventReaderBase.java
@@ -443,7 +443,8 @@ public abstract class JHFEventReaderBase extends JobEntityCreationPublisher impl
                 jobExecutionEntity.getFailedTasks().put(taskID,
                     new HashMap<String, String>() {
                         {
-                            put(entity.getTags().get(MRJobTagName.ERROR_CATEGORY.toString()), entity.getError());
+                            put(entity.getTags().get(MRJobTagName.ERROR_CATEGORY.toString()),
+                                entity.getTags().get(MRJobTagName.ERROR_CATEGORY.toString()));//decide later
                         }
                     }
                 );

--- a/eagle-jpm/eagle-jpm-mr-history/src/main/resources/META-INF/providers/org.apache.eagle.jpm.mr.history.MRHistoryJobApplicationProvider.xml
+++ b/eagle-jpm/eagle-jpm-mr-history/src/main/resources/META-INF/providers/org.apache.eagle.jpm.mr.history.MRHistoryJobApplicationProvider.xml
@@ -20,7 +20,6 @@
     <type>MR_HISTORY_JOB_APP</type>
     <name>Map Reduce History Job Monitoring</name>
     <version>0.5.0-incubating</version>
-    <appClass>org.apache.eagle.jpm.mr.history.MRHistoryJobApplication</appClass>
     <configuration>
         <!-- org.apache.eagle.jpm.mr.history.MRHistoryJobConfig -->
         <property>

--- a/eagle-jpm/eagle-jpm-mr-history/src/main/resources/application.conf
+++ b/eagle-jpm/eagle-jpm-mr-history/src/main/resources/application.conf
@@ -15,9 +15,6 @@
 
 {
   "envContextConfig" : {
-    "env" : "local",
-    "topologyName" : "mrHistoryJob",
-    "stormConfigFile" : "storm.yaml",
     "parallelismConfig" : {
       "mrHistoryJobExecutor" : 6
     },

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/MRRunningJobApplication.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/MRRunningJobApplication.java
@@ -26,6 +26,8 @@ import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
 import com.typesafe.config.Config;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class MRRunningJobApplication extends StormApplication {
@@ -34,7 +36,11 @@ public class MRRunningJobApplication extends StormApplication {
         //1. trigger init conf
         MRRunningJobConfig mrRunningJobConfig = MRRunningJobConfig.getInstance(config);
 
-        List<String> confKeyKeys = mrRunningJobConfig.getConfig().getStringList("MRConfigureKeys.jobConfigKey");
+        String[] confKeyPatternsSplit = mrRunningJobConfig.getConfig().getString("MRConfigureKeys.jobConfigKey").split(",");
+        List<String> confKeyKeys = new ArrayList<>(confKeyPatternsSplit.length);
+        for (String confKeyPattern : confKeyPatternsSplit) {
+            confKeyKeys.add(confKeyPattern.trim());
+        }
         confKeyKeys.add(Constants.JobConfiguration.CASCADING_JOB);
         confKeyKeys.add(Constants.JobConfiguration.HIVE_JOB);
         confKeyKeys.add(Constants.JobConfiguration.PIG_JOB);

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/MRRunningJobConfig.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/MRRunningJobConfig.java
@@ -29,12 +29,6 @@ import java.io.Serializable;
 public class MRRunningJobConfig implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(MRRunningJobConfig.class);
 
-    public String getEnv() {
-        return env;
-    }
-
-    private String env;
-
     public ZKStateConfig getZkStateConfig() {
         return zkStateConfig;
     }
@@ -120,7 +114,6 @@ public class MRRunningJobConfig implements Serializable {
 
     private void init(Config config) {
         this.config = config;
-        this.env = config.getString("envContextConfig.env");
 
         //parse eagle zk
         this.zkStateConfig.zkQuorum = config.getString("zookeeperConfig.zkQuorum");
@@ -148,7 +141,6 @@ public class MRRunningJobConfig implements Serializable {
         this.endpointConfig.rmUrls = config.getString("dataSourceConfig.rmUrls").split(",");
 
         LOG.info("Successfully initialized MRRunningJobConfig");
-        LOG.info("env: " + this.env);
         LOG.info("site: " + this.jobExtractorConfig.site);
         LOG.info("eagle.service.host: " + this.eagleServiceConfig.eagleServiceHost);
         LOG.info("eagle.service.port: " + this.eagleServiceConfig.eagleServicePort);

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/resources/META-INF/providers/org.apache.eagle.jpm.mr.running.MRRunningJobApplicationProvider.xml
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/resources/META-INF/providers/org.apache.eagle.jpm.mr.running.MRRunningJobApplicationProvider.xml
@@ -20,7 +20,6 @@
     <type>MR_RUNNING_JOB_APP</type>
     <name>MR Running Job Monitoring</name>
     <version>0.5.0-incubating</version>
-    <appClass>org.apache.eagle.jpm.mr.running.MRRunningJobApplication</appClass>
     <configuration>
         <!-- org.apache.eagle.jpm.spark.running.SparkRunningJobAppConfig -->
         <property>

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/resources/application.conf
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/resources/application.conf
@@ -19,8 +19,6 @@
   application.storm.nimbusHost=localhost,
   "workers" : 8,
   "envContextConfig" : {
-    "env" : "local",
-    "topologyName" : "mrRunningJob",
     "stormConfigFile" : "storm.yaml",
     "parallelismConfig" : {
       "mrRunningJobFetchSpout" : 1,
@@ -67,24 +65,6 @@
 
   "MRConfigureKeys" : {
     "jobNameKey" : "eagle.job.name",
-    "jobConfigKey" : [
-      "mapreduce.map.output.compress",
-      "mapreduce.map.output.compress.codec",
-      "mapreduce.output.fileoutputformat.compress",
-      "mapreduce.output.fileoutputformat.compress.type",
-      "mapreduce.output.fileoutputformat.compress.codec",
-      "mapred.output.format.class",
-      "eagle.job.runid",
-      "eagle.job.runidfieldname",
-      "eagle.job.name",
-      "eagle.job.normalizedfieldname",
-      "eagle.alert.email",
-      "eagle.job.alertemailaddress",
-      "dataplatform.etl.info",
-      "mapreduce.map.memory.mb",
-      "mapreduce.reduce.memory.mb",
-      "mapreduce.map.java.opts",
-      "mapreduce.reduce.java.opts"
-    ]
+    "jobConfigKey" : "mapreduce.map.output.compress, mapreduce.map.output.compress.codec, mapreduce.output.fileoutputformat.compress, mapreduce.output.fileoutputformat.compress.type, mapreduce.output.fileoutputformat.compress.codec, mapred.output.format.class, eagle.job.runid, eagle.job.runidfieldname, eagle.job.name, eagle.job.normalizedfieldname, eagle.alert.email, eagle.job.alertemailaddress, dataplatform.etl.info, mapreduce.map.memory.mb, mapreduce.reduce.memory.mb, mapreduce.map.java.opts, mapreduce.reduce.java.opts"
   }
 }

--- a/eagle-jpm/eagle-jpm-util/pom.xml
+++ b/eagle-jpm/eagle-jpm-util/pom.xml
@@ -68,5 +68,10 @@
             <artifactId>commons-codec</artifactId>
             <version>1.9</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/HDFSUtil.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/HDFSUtil.java
@@ -34,7 +34,9 @@ public class HDFSUtil {
 
     public static void login(Configuration kConfig) throws IOException {
         if (kConfig.get("hdfs.kerberos.principal") == null || kConfig.get("hdfs.kerberos.principal").isEmpty()) {
-            System.setProperty("HADOOP_USER_NAME", kConfig.get("hadoop.job.ugi"));
+            if (kConfig.get("hadoop.job.ugi") != null) {
+                System.setProperty("HADOOP_USER_NAME", kConfig.get("hadoop.job.ugi"));
+            }
             return;
         }
         kConfig.setBoolean("hadoop.security.authorization", true);

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/HDFSUtil.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/HDFSUtil.java
@@ -34,6 +34,7 @@ public class HDFSUtil {
 
     public static void login(Configuration kConfig) throws IOException {
         if (kConfig.get("hdfs.kerberos.principal") == null || kConfig.get("hdfs.kerberos.principal").isEmpty()) {
+            System.setProperty("HADOOP_USER_NAME", kConfig.get("hadoop.job.ugi"));
             return;
         }
         kConfig.setBoolean("hadoop.security.authorization", true);

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/resourcefetch/model/MrJobs.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/resourcefetch/model/MrJobs.java
@@ -31,7 +31,7 @@ public class MrJobs {
         return job;
     }
 
-    public void setJobs(List<MRJob> job) {
+    public void setJob(List<MRJob> job) {
         this.job = job;
     }
 

--- a/eagle-topology-assembly/pom.xml
+++ b/eagle-topology-assembly/pom.xml
@@ -34,6 +34,21 @@
             <artifactId>eagle-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-jpm-mr-history</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-jpm-mr-running</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-jpm-web</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/eagle-topology-assembly/src/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/eagle-topology-assembly/src/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.eagle.security.hbase.HBaseAuditLogAppProvider
-org.apache.eagle.app.example.ExampleApplicationProvider
-org.apache.eagle.app.jpm.JPMWebApplicationProvider
-org.apache.eagle.jpm.mr.history.MRHistoryJobApplicationProvider
-org.apache.eagle.jpm.mr.running.MRRunningJobApplicationProvider
+org.apache.hadoop.hdfs.DistributedFileSystem
+org.apache.hadoop.hdfs.web.HftpFileSystem
+org.apache.hadoop.hdfs.web.HsftpFileSystem
+org.apache.hadoop.hdfs.web.WebHdfsFileSystem
+org.apache.hadoop.hdfs.web.SWebHdfsFileSystem


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-564

Pack MR history/Running feeder in the final topology by using topology-assembly. 
Changes:
1. remove useless configure
2. add application provider to topology assembly spi
Bug fix:
1. Storm configure(workers/timeout...) does not overrided by customer defined configure.
2. When install an application, user may not set jarPath, in this case, we need to dynamic load, otherwise, use the jarPath that user provides.