### PR TITLE
EAGLE-565 Because of the "type" field when has subqueue ,response of RM REST API doesn‘t match the SchedulerWrapper object

### DIFF
--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/Queue.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/Queue.java
@@ -24,7 +24,6 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Queue {
-    private String type;
     private double capacity;
     private double usedCapacity;
     private double maxCapacity;
@@ -119,15 +118,6 @@ public class Queue {
 
     public void setUserLimitFactor(int userLimitFactor) {
         this.userLimitFactor = userLimitFactor;
-    }
-
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
     }
 
     public ResourcesUsed getResourcesUsed() {


### PR DESCRIPTION
EAGLE-565 Because of the "type" field when has subqueue ,response of RM REST API doesn‘t match the SchedulerWrapper object
- remove the "type" field in class Queue.

https://issues.apache.org/jira/browse/EAGLE-565