### PR TITLE
EAGLE-565 Because of the "type" field when has subqueue ,response of RM REST API doesn‘t match the SchedulerWrapper object

### DIFF
--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/Queue.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/Queue.java
@@ -24,7 +24,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Queue {
-    private String type;
+    //private String type;   workaround the YARN-4785,the field's value is based on the "type" field of SchedulerInfo.java, then its getter and setter function is never used.
     private double capacity;
     private double usedCapacity;
     private double maxCapacity;
@@ -122,13 +122,13 @@ public class Queue {
     }
 
 
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
+    //    public String getType() {
+    //        return type;
+    //    }
+    //
+    //    public void setType(String type) {
+    //        this.type = type;
+    //    }
 
     public ResourcesUsed getResourcesUsed() {
         return resourcesUsed;


### PR DESCRIPTION
EAGLE-565 Because of the "type" field when has subqueue ,response of RM REST API doesn‘t match the SchedulerWrapper object
- Ignore and add comments on the "type" field in class Queue, in order to workaround YARN-4785
https://issues.apache.org/jira/browse/EAGLE-565