### PR TITLE
[EAGLE-432] Application status monitoring

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/ExecutionRuntime.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/ExecutionRuntime.java
@@ -18,6 +18,7 @@ package org.apache.eagle.app.environment;
 
 import org.apache.eagle.app.Application;
 import com.typesafe.config.Config;
+import org.apache.eagle.metadata.model.ApplicationEntity;
 
 /**
  * Execution Runtime Adapter.
@@ -54,6 +55,7 @@ public interface ExecutionRuntime<E extends Environment, P> {
      *
      * @param executor
      * @param config
+     * @return status
      */
-    void status(Application<E, P> executor, Config config);
+    ApplicationEntity.Status status(Application<E, P> executor, Config config);
 }

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/impl/SparkExecutionRuntime.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/impl/SparkExecutionRuntime.java
@@ -20,6 +20,7 @@ import org.apache.eagle.app.Application;
 import org.apache.eagle.app.environment.ExecutionRuntime;
 import org.apache.eagle.app.environment.ExecutionRuntimeProvider;
 import com.typesafe.config.Config;
+import org.apache.eagle.metadata.model.ApplicationEntity;
 
 public class SparkExecutionRuntime implements ExecutionRuntime<SparkEnvironment,Object> {
     @Override
@@ -43,7 +44,7 @@ public class SparkExecutionRuntime implements ExecutionRuntime<SparkEnvironment,
     }
 
     @Override
-    public void status(Application executor, Config config) {
+    public ApplicationEntity.Status status(Application executor, Config config) {
         throw new RuntimeException("Not implemented yet");
     }
 

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/impl/WebExecutionRuntime.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/impl/WebExecutionRuntime.java
@@ -21,6 +21,7 @@ import com.typesafe.config.Config;
 import org.apache.eagle.app.Application;
 import org.apache.eagle.app.environment.ExecutionRuntime;
 import org.apache.eagle.app.environment.ExecutionRuntimeProvider;
+import org.apache.eagle.metadata.model.ApplicationEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +54,9 @@ public class WebExecutionRuntime implements ExecutionRuntime<WebEnvironment,WebE
     }
 
     @Override
-    public void status(Application<WebEnvironment, WebExecutionContainer> executor, Config config) {
+    public ApplicationEntity.Status status(Application<WebEnvironment, WebExecutionContainer> executor, Config config) {
         LOGGER.warn("Checking status {}, do nothing",executor);
+        return ApplicationEntity.Status.INITIALIZED;
     }
 
     public static class Provider implements ExecutionRuntimeProvider<WebEnvironment,WebExecutionContainer> {

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/module/ApplicationGuiceModule.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/module/ApplicationGuiceModule.java
@@ -19,10 +19,12 @@ package org.apache.eagle.app.module;
 import org.apache.eagle.app.service.ApplicationManagementService;
 import org.apache.eagle.app.service.ApplicationProviderService;
 import org.apache.eagle.app.service.impl.ApplicationManagementServiceImpl;
+import org.apache.eagle.app.service.impl.ApplicationStatusUpdateServiceImpl;
 import org.apache.eagle.metadata.service.ApplicationDescService;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.util.Providers;
+import org.apache.eagle.metadata.service.ApplicationStatusUpdateService;
 
 public class ApplicationGuiceModule extends AbstractModule {
     private ApplicationProviderService appProviderInst;
@@ -36,5 +38,6 @@ public class ApplicationGuiceModule extends AbstractModule {
         bind(ApplicationProviderService.class).toProvider(Providers.of(appProviderInst));
         bind(ApplicationDescService.class).toProvider(Providers.of(appProviderInst));
         bind(ApplicationManagementService.class).to(ApplicationManagementServiceImpl.class).in(Singleton.class);
+        bind(ApplicationStatusUpdateService.class).to(ApplicationStatusUpdateServiceImpl.class).in(Singleton.class);
     }
 }

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/resource/ApplicationResource.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/resource/ApplicationResource.java
@@ -90,6 +90,18 @@ public class ApplicationResource {
         return RESTResponse.async(() -> entityService.getByUUID(appUuid)).get();
     }
 
+    @POST
+    @Path("/status")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RESTResponse<ApplicationEntity.Status> checkApplicationStatusByUUID(ApplicationOperations.CheckStatusOperation operation) {
+        return RESTResponse.<ApplicationEntity.Status>async((response) -> {
+            ApplicationEntity.Status status = (entityService.getByUUIDOrAppId(null, operation.getAppId())).getStatus();
+            response.success(true).message("Successfully fetched application status");
+            response.data(status);
+        }).get();
+    }
+
     /**
      * <b>Request:</b>
      * <pre>
@@ -148,7 +160,7 @@ public class ApplicationResource {
     public RESTResponse<Void> startApplication(ApplicationOperations.StartOperation operation) {
         return RESTResponse.<Void>async((response) -> {
             ApplicationEntity entity = applicationManagementService.start(operation);
-            response.success(true).message("Successfully started application " + entity.getUuid());
+            response.success(true).message("Starting application " + entity.getUuid());
         }).get();
     }
 
@@ -169,7 +181,8 @@ public class ApplicationResource {
     public RESTResponse<Void> stopApplication(ApplicationOperations.StopOperation operation) {
         return RESTResponse.<Void>async((response) -> {
             ApplicationEntity entity = applicationManagementService.stop(operation);
-            response.success(true).message("Successfully stopped application " + entity.getUuid());
+            response.success(true).message("Stopping application " + entity.getUuid());
         }).get();
     }
+
 }

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationManagementService.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationManagementService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.eagle.app.service;
 
+import org.apache.eagle.metadata.exceptions.ApplicationWrongStatusException;
 import org.apache.eagle.metadata.exceptions.EntityNotFoundException;
 import org.apache.eagle.metadata.model.ApplicationEntity;
 
@@ -34,7 +35,7 @@ public interface ApplicationManagementService {
      * @param operation
      * @return
      */
-    ApplicationEntity uninstall(ApplicationOperations.UninstallOperation operation);
+    ApplicationEntity uninstall(ApplicationOperations.UninstallOperation operation) throws ApplicationWrongStatusException;
 
     /**
      * Start application.
@@ -42,7 +43,7 @@ public interface ApplicationManagementService {
      * @param operation
      * @return
      */
-    ApplicationEntity start(ApplicationOperations.StartOperation operation);
+    ApplicationEntity start(ApplicationOperations.StartOperation operation) throws ApplicationWrongStatusException;
 
     /**
      * Stop application.
@@ -50,5 +51,14 @@ public interface ApplicationManagementService {
      * @param operation
      * @return
      */
-    ApplicationEntity stop(ApplicationOperations.StopOperation operation);
+    ApplicationEntity stop(ApplicationOperations.StopOperation operation) throws ApplicationWrongStatusException;
+
+    /**
+     * get application status.
+     *
+     * @param operation
+     * @return
+     */
+    ApplicationEntity.Status getStatus(ApplicationOperations.CheckStatusOperation operation) throws EntityNotFoundException;
+
 }

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationOperationContext.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationOperationContext.java
@@ -24,7 +24,6 @@ import org.apache.eagle.alert.engine.scheme.JsonStringStreamNameSelector;
 import org.apache.eagle.alert.metadata.IMetadataDao;
 import org.apache.eagle.app.Application;
 import org.apache.eagle.app.ApplicationLifecycle;
-import org.apache.eagle.app.StaticWebApplication;
 import org.apache.eagle.app.environment.ExecutionRuntime;
 import org.apache.eagle.app.environment.ExecutionRuntimeManager;
 import org.apache.eagle.app.sink.KafkaStreamSinkConfig;
@@ -145,6 +144,10 @@ public class ApplicationOperationContext implements Serializable, ApplicationLif
     @Override
     public void onStop() {
         this.runtime.stop(this.application, this.config);
+    }
+
+    public ApplicationEntity.Status getStatus() {
+        return this.runtime.status(this.application, this.config);
     }
 
     public ApplicationEntity getMetadata() {

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationOperations.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationOperations.java
@@ -52,10 +52,18 @@ public final class ApplicationOperations {
             this.setMode(mode);
         }
 
-        public InstallOperation(String siteId, String appType, ApplicationEntity.Mode mode, Map<String, Object> configuration) {
+        public InstallOperation(String siteId, String appType, ApplicationEntity.Mode mode, String jarPath) {
             this.setSiteId(siteId);
             this.setAppType(appType);
             this.setMode(mode);
+            this.setJarPath(jarPath);
+        }
+
+        public InstallOperation(String siteId, String appType, ApplicationEntity.Mode mode, String jarPath, Map<String, Object> configuration) {
+            this.setSiteId(siteId);
+            this.setAppType(appType);
+            this.setMode(mode);
+            this.setJarPath(jarPath);
             this.setConfiguration(configuration);
         }
 
@@ -216,6 +224,44 @@ public final class ApplicationOperations {
         @Override
         public String getType() {
             return STOP;
+        }
+    }
+
+    public static class CheckStatusOperation implements Operation {
+        private String uuid;
+        private String appId;
+
+        public CheckStatusOperation() {
+        }
+
+        public CheckStatusOperation(String uuid) {
+            this.setUuid(uuid);
+        }
+
+        public CheckStatusOperation(String uuid, String appId) {
+            this.setUuid(uuid);
+            this.setAppId(appId);
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public void setUuid(String uuid) {
+            this.uuid = uuid;
+        }
+
+        public String getAppId() {
+            return appId;
+        }
+
+        public void setAppId(String appId) {
+            this.appId = appId;
+        }
+
+        @Override
+        public String getType() {
+            return START;
         }
     }
 }

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/impl/ApplicationStatusUpdateServiceImpl.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/impl/ApplicationStatusUpdateServiceImpl.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.app.service.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.eagle.app.service.ApplicationOperations;
+import org.apache.eagle.metadata.model.ApplicationEntity;
+import org.apache.eagle.metadata.service.ApplicationEntityService;
+import org.apache.eagle.metadata.service.ApplicationStatusUpdateService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class ApplicationStatusUpdateServiceImpl extends  ApplicationStatusUpdateService {
+    private static final Logger LOG = LoggerFactory.getLogger(ApplicationStatusUpdateServiceImpl.class);
+    private final ApplicationEntityService applicationEntityService;
+    private final ApplicationManagementServiceImpl applicationManagementService;
+
+    // default value 10, 10
+    private  int initialDelay = 10;
+    private  int period = 10;
+
+
+    @Inject
+    public ApplicationStatusUpdateServiceImpl(ApplicationEntityService applicationEntityService, ApplicationManagementServiceImpl applicationManagementService) {
+        this.applicationEntityService = applicationEntityService;
+        this.applicationManagementService = applicationManagementService;
+    }
+
+    @Override
+    protected void runOneIteration() throws Exception {
+        LOG.info("Checking app status");
+        try {
+            Collection<ApplicationEntity> applicationEntities = applicationEntityService.findAll();
+            for (ApplicationEntity applicationEntity: applicationEntities) {
+                updateApplicationEntityStatus(applicationEntity);
+            }
+        } catch (Exception e) {
+            LOG.error("failed to update app status", e);
+        }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        try {
+            Config config = ConfigFactory.load();
+            initialDelay = config.getInt("application.updateStatus.initialDelay");
+            period = config.getInt("application.updateStatus.period");
+        } catch (Exception e) {
+            LOG.error("Failed to get configuration for application updateStatus service, using default value", e);
+        }
+        return Scheduler.newFixedRateSchedule(initialDelay, period, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void updateApplicationEntityStatus(Collection<ApplicationEntity> applicationEntities) {}
+
+    @Override
+    public void updateApplicationEntityStatus(ApplicationEntity applicationEntity) {
+        String appUuid = applicationEntity.getUuid();
+        ApplicationEntity.Status currentStatus = applicationEntity.getStatus();
+        try {
+            ApplicationEntity.Status topologyStatus = applicationManagementService.getStatus(new ApplicationOperations.CheckStatusOperation(appUuid));
+            if (currentStatus == ApplicationEntity.Status.STARTING) {
+                if (topologyStatus == ApplicationEntity.Status.RUNNING) {
+                    applicationEntityService.delete(applicationEntity);
+                    applicationEntity.setStatus(ApplicationEntity.Status.RUNNING);
+                    applicationEntityService.create(applicationEntity);
+                    // handle the topology corruption case:
+                } else if (topologyStatus == ApplicationEntity.Status.REMOVED) {
+                    applicationEntityService.delete(applicationEntity);
+                    applicationEntity.setStatus(ApplicationEntity.Status.INITIALIZED);
+                    applicationEntityService.create(applicationEntity);
+                }
+            } else if (currentStatus == ApplicationEntity.Status.STOPPING) {
+                if (topologyStatus == ApplicationEntity.Status.REMOVED) {
+                    applicationEntityService.delete(applicationEntity);
+                    applicationEntity.setStatus(ApplicationEntity.Status.INITIALIZED);
+                    applicationEntityService.create(applicationEntity);
+                }
+            } else if (currentStatus == ApplicationEntity.Status.RUNNING) {
+                // handle the topology corruption case:
+                if (topologyStatus == ApplicationEntity.Status.REMOVED) {
+                    applicationEntityService.delete(applicationEntity);
+                    applicationEntity.setStatus(ApplicationEntity.Status.INITIALIZED);
+                    applicationEntityService.create(applicationEntity);
+                }
+            } else if (currentStatus == ApplicationEntity.Status.INITIALIZED) {
+                //corner case: when Storm service go down, app status-> initialized,
+                //then when storm server is up again, storm topology will be launched automatically->active
+                if (topologyStatus == ApplicationEntity.Status.RUNNING) {
+                    applicationEntityService.delete(applicationEntity);
+                    applicationEntity.setStatus(ApplicationEntity.Status.RUNNING);
+                    applicationEntityService.create(applicationEntity);
+                }
+            }
+            //"STOPPED" is not used in Eagle, so just do nothing.
+        } catch (RuntimeException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+}

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/impl/ApplicationStatusUpdateServiceImpl.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/impl/ApplicationStatusUpdateServiceImpl.java
@@ -36,9 +36,9 @@ public class ApplicationStatusUpdateServiceImpl extends  ApplicationStatusUpdate
     private final ApplicationEntityService applicationEntityService;
     private final ApplicationManagementServiceImpl applicationManagementService;
 
-    // default value 10, 10
-    private  int initialDelay = 10;
-    private  int period = 10;
+    // default value 30, 30
+    private  int initialDelay = 30;
+    private  int period = 30;
 
 
     @Inject
@@ -62,13 +62,6 @@ public class ApplicationStatusUpdateServiceImpl extends  ApplicationStatusUpdate
 
     @Override
     protected Scheduler scheduler() {
-        try {
-            Config config = ConfigFactory.load();
-            initialDelay = config.getInt("application.updateStatus.initialDelay");
-            period = config.getInt("application.updateStatus.period");
-        } catch (Exception e) {
-            LOG.error("Failed to get configuration for application updateStatus service, using default value", e);
-        }
         return Scheduler.newFixedRateSchedule(initialDelay, period, TimeUnit.SECONDS);
     }
 

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/exceptions/ApplicationWrongStatusException.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/exceptions/ApplicationWrongStatusException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.metadata.exceptions;
+
+public class ApplicationWrongStatusException extends Exception {
+    public ApplicationWrongStatusException(String message) {
+        super(message);
+    }
+
+    public ApplicationWrongStatusException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ApplicationWrongStatusException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/ApplicationEntity.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/ApplicationEntity.java
@@ -159,7 +159,10 @@ public class ApplicationEntity extends PersistenceEntity {
         STARTING("STARTING"),
         RUNNING("RUNNING"),
         STOPPING("STOPPING"),
-        STOPPED("STOPPED");
+        //Todo: currently "stopped" is not used, because "STOP" operation in Eagle equals to "KILL"
+        STOPPED("STOPPED"),
+        REMOVED("REMOVED"),
+        UNKNOWN("UNKNOWN");
 
         private final String status;
 

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/ApplicationStatusUpdateService.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/ApplicationStatusUpdateService.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.metadata.service;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import org.apache.eagle.metadata.model.ApplicationEntity;
+
+import java.util.Collection;
+
+public abstract class ApplicationStatusUpdateService extends AbstractScheduledService {
+    public abstract void updateApplicationEntityStatus(Collection<ApplicationEntity> applicationEntities);
+    public abstract void updateApplicationEntityStatus(ApplicationEntity applicationEntity);
+ }

--- a/eagle-examples/eagle-app-example/src/test/java/org/apache/eagle/app/example/ExampleApplicationProviderTest.java
+++ b/eagle-examples/eagle-app-example/src/test/java/org/apache/eagle/app/example/ExampleApplicationProviderTest.java
@@ -28,6 +28,7 @@ import org.apache.eagle.metadata.model.ApplicationDesc;
 import org.apache.eagle.metadata.model.ApplicationEntity;
 import org.apache.eagle.metadata.model.SiteEntity;
 import org.apache.eagle.metadata.resource.SiteResource;
+import org.apache.eagle.metadata.service.ApplicationStatusUpdateService;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,6 +46,8 @@ public class ExampleApplicationProviderTest extends ApplicationTestBase {
     private ApplicationSimulator simulator;
     @Inject
     private ExampleResource exampleResource;
+    @Inject
+    ApplicationStatusUpdateService statusUpdateService;
 
     @Test
     public void testApplicationProviderLoading() {
@@ -86,8 +89,10 @@ public class ExampleApplicationProviderTest extends ApplicationTestBase {
         ApplicationEntity applicationEntity = applicationResource.installApplication(installOperation).getData();
         // Start application
         applicationResource.startApplication(new ApplicationOperations.StartOperation(applicationEntity.getUuid()));
+        statusUpdateService.updateApplicationEntityStatus(applicationEntity);
         // Stop application
         applicationResource.stopApplication(new ApplicationOperations.StopOperation(applicationEntity.getUuid()));
+        statusUpdateService.updateApplicationEntityStatus(applicationEntity);
         // Uninstall application
         applicationResource.uninstallApplication(new ApplicationOperations.UninstallOperation(applicationEntity.getUuid()));
         try {

--- a/eagle-jpm/eagle-jpm-web/src/test/java/org/apache/eagle/app/jpm/JPMWebApplicationTest.java
+++ b/eagle-jpm/eagle-jpm-web/src/test/java/org/apache/eagle/app/jpm/JPMWebApplicationTest.java
@@ -24,6 +24,7 @@ import org.apache.eagle.metadata.model.SiteEntity;
 import org.apache.eagle.metadata.resource.SiteResource;
 
 import com.google.inject.Inject;
+import org.apache.eagle.metadata.service.ApplicationStatusUpdateService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,9 @@ public class JPMWebApplicationTest extends ApplicationTestBase {
 
     @Inject
     private ApplicationResource applicationResource;
+
+    @Inject
+    private ApplicationStatusUpdateService statusUpdateService;
 
     private void installDependencies(){
         ApplicationOperations.InstallOperation installDependency1 = new ApplicationOperations.InstallOperation("test_site", "MR_RUNNING_JOB_APP", ApplicationEntity.Mode.LOCAL);
@@ -74,12 +78,12 @@ public class JPMWebApplicationTest extends ApplicationTestBase {
 
         // Install application
         ApplicationEntity applicationEntity = applicationResource.installApplication(installOperation).getData();
-
+        //Todo: comment these for now, because they haven't been implemented
         // Start application
-        applicationResource.startApplication(new ApplicationOperations.StartOperation(applicationEntity.getUuid()));
-        // Stop application
-        applicationResource.stopApplication(new ApplicationOperations.StopOperation(applicationEntity.getUuid()));
-        // Uninstall application
+//        applicationResource.startApplication(new ApplicationOperations.StartOperation(applicationEntity.getUuid()));
+//        // Stop application
+//        applicationResource.stopApplication(new ApplicationOperations.StopOperation(applicationEntity.getUuid()));
+        //Uninstall application
         applicationResource.uninstallApplication(new ApplicationOperations.UninstallOperation(applicationEntity.getUuid()));
         try {
             applicationResource.getApplicationEntityByUUID(applicationEntity.getUuid());

--- a/eagle-server/src/main/java/org/apache/eagle/server/managedtask/ApplicationTask.java
+++ b/eagle-server/src/main/java/org/apache/eagle/server/managedtask/ApplicationTask.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ApplicationTask implements Managed {
-    private final static Logger LOG = LoggerFactory.getLogger(ApplicationStatusUpdateServiceImpl.class);
+    private final static Logger LOG = LoggerFactory.getLogger(ApplicationTask.class);
     private final AbstractScheduledService service;
 
     public ApplicationTask(AbstractScheduledService service){

--- a/eagle-server/src/main/java/org/apache/eagle/server/managedtask/ApplicationTask.java
+++ b/eagle-server/src/main/java/org/apache/eagle/server/managedtask/ApplicationTask.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.server.managedtask;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.eagle.app.service.impl.ApplicationStatusUpdateServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ApplicationTask implements Managed {
+    private final static Logger LOG = LoggerFactory.getLogger(ApplicationStatusUpdateServiceImpl.class);
+    private final AbstractScheduledService service;
+
+    public ApplicationTask(AbstractScheduledService service){
+        this.service = service;
+    }
+
+    @Override
+    public void start() throws Exception {
+        LOG.info("Application update task started:");
+        service.startAsync().awaitRunning();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        service.stopAsync().awaitTerminated();
+    }
+}

--- a/eagle-server/src/main/resources/application.conf
+++ b/eagle-server/src/main/resources/application.conf
@@ -80,6 +80,10 @@ application {
     nimbusHost = "server.eagle.apache.org"
     nimbusThriftPort = 6627
   }
+  updateStatus: {
+    initialDelay: 10
+    period: 10
+  }
 }
 
 # ---------------------------------------------


### PR DESCRIPTION
<!--
{% comment %}
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to you under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
{% endcomment %}
-->

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[EAGLE-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
- REST API call of app status can return:
   "INITIALIZED"
   "STARTING"
   "RUNNING"
   "STOPPING"

- Added CheckStatus Operation as a new application Operation

- ApplicationStatusUpdateService will probe topology status periodically  and update the status in application Entity, this background task is based on "guava". The initial delay and period setting can be set in configuration file.

- status() in StormExecutionRuntime supports both  "LOCAL" and "CLUSTER"