### PR TITLE
EAGLE-579: Cloned stream alert event missed stream name

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/DedupCache.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/DedupCache.java
@@ -212,7 +212,7 @@ public class DedupCache {
             DedupValue dedupValue = dedupValues.getLast();
             dedupValue.setCount(dedupValue.getCount() + 1);
             String updateMsg = String.format(
-                "{} Update count for dedup key %s, value %s and count %s", this.publishName, eventEniq,
+                "%s Update count for dedup key %s, value %s and count %s", this.publishName, eventEniq,
                 dedupValue.getStateFieldValue(), dedupValue.getCount());
             if (dedupValue.getCount() > 0 && dedupValue.getCount() % 100 == 0) {
                 LOG.info(updateMsg);
@@ -233,6 +233,7 @@ public class DedupCache {
             newdata[i] = originalEvent.getData()[i];
         }
         event.setData(newdata);
+        event.setStreamId(originalEvent.getStreamId());
         event.setSchema(originalEvent.getSchema());
         event.setPolicyId(originalEvent.getPolicyId());
         event.setCreatedTime(originalEvent.getCreatedTime());

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/ExtendedDeduplicator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/ExtendedDeduplicator.java
@@ -31,12 +31,14 @@ public abstract class ExtendedDeduplicator implements AlertDeduplicator {
     private List<String> customDedupFields;
     private String dedupStateField;
     private Config config;
+    private String publishName;
 
     public ExtendedDeduplicator(Config config,
                                 Map<String, String> properties,
                                 List<String> customDedupFields,
                                 String dedupStateField,
-                                DedupCache dedupCache) {
+                                DedupCache dedupCache,
+                                String publishName) {
         this.properties = properties;
         if (this.properties == null) {
             this.properties = new HashMap<String, String>();
@@ -45,6 +47,7 @@ public abstract class ExtendedDeduplicator implements AlertDeduplicator {
         this.customDedupFields = customDedupFields;
         this.dedupStateField = dedupStateField;
         this.config = config;
+        this.publishName = publishName;
     }
 
     public Map<String, String> getProperties() {
@@ -65,6 +68,14 @@ public abstract class ExtendedDeduplicator implements AlertDeduplicator {
 
     public Config getConfig() {
         return config;
+    }
+
+    public String getPublishName() {
+        return publishName;
+    }
+
+    public void setPublishName(String publishName) {
+        this.publishName = publishName;
     }
 
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
@@ -57,14 +57,16 @@ public abstract class AbstractPublishPlugin implements AlertPublishPlugin {
                     Map.class,
                     List.class,
                     String.class,
-                    DedupCache.class).newInstance(
+                    DedupCache.class,
+                    String.class).newInstance(
                     config,
                     spec.getProperties(),
                     publishment.getDedupFields(),
                     publishment.getDedupStateField(),
-                    dedupCache);
-                getLogger().info("initiliazed extended deduplicator {} with properties {} successfully",
-                    spec.getClassName(), Joiner.on(",").withKeyValueSeparator(">").join(
+                    dedupCache,
+                    publishment.getName());
+                getLogger().info("{} initiliazed extended deduplicator {} with properties {} successfully",
+                    publishment.getName(), spec.getClassName(), Joiner.on(",").withKeyValueSeparator(">").join(
                         spec.getProperties() == null ? new HashMap<String, String>() : spec.getProperties()));
             } catch (Throwable t) {
                 getLogger().error(String.format("initialize extended deduplicator %s failed", spec.getClassName()), t);

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/TestDeduplicator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/TestDeduplicator.java
@@ -33,8 +33,8 @@ import java.util.Map;
 public class TestDeduplicator extends ExtendedDeduplicator {
 
     public TestDeduplicator(Config config, Map<String, String> properties, List<String> customDedupFields,
-			String dedupStateField, DedupCache dedupCache) {
-		super(config, properties, customDedupFields, dedupStateField, dedupCache);
+			String dedupStateField, DedupCache dedupCache, String publishName) {
+		super(config, properties, customDedupFields, dedupStateField, dedupCache, publishName);
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(TestDeduplicator.class);


### PR DESCRIPTION
We are trying to clone stream alert event if there is a state transition (we need to update last state dedup count and first occurrence time). If the cloned stream alert event missed the stream name, the publishment cannot work.