### PR TITLE
[EAGLE-587]: AlertEngine : simplify state-based dedup to have only deupvalue for given dedup key

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
@@ -35,6 +35,7 @@ public class Publishment {
     private String dedupIntervalMin;
     private List<String> dedupFields;
     private String dedupStateField;
+    private String dedupStateCloseValue;
     private OverrideDeduplicatorSpec overrideDeduplicator;
     private Map<String, String> properties;
     // the class name to extend the IEventSerializer interface
@@ -54,6 +55,14 @@ public class Publishment {
 
     public void setDedupStateField(String dedupStateField) {
         this.dedupStateField = dedupStateField;
+    }
+
+    public String getDedupStateCloseValue() {
+        return dedupStateCloseValue;
+    }
+
+    public void setDedupStateCloseValue(String dedupStateCloseValue) {
+        this.dedupStateCloseValue = dedupStateCloseValue;
     }
 
     public OverrideDeduplicatorSpec getOverrideDeduplicator() {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/DedupValue.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/DedupValue.java
@@ -23,12 +23,18 @@ public class DedupValue {
     private long firstOccurrence;
     private String stateFieldValue;
     private long count;
+    private long closeTime;
+    private String docId;
 
     public DedupValue() {
     }
 
-    public DedupValue(String stateFieldValue) {
-        this.stateFieldValue = stateFieldValue;
+    public void resetTo(DedupValue dv) {
+        this.docId = dv.docId;
+        this.firstOccurrence = dv.firstOccurrence;
+        this.count = dv.count;
+        this.closeTime = dv.closeTime;
+        this.stateFieldValue = dv.stateFieldValue;
     }
 
     public long getCount() {
@@ -39,12 +45,28 @@ public class DedupValue {
         this.count = count;
     }
 
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
+    }
+
     public long getFirstOccurrence() {
         return firstOccurrence;
     }
 
     public void setFirstOccurrence(long firstOccurence) {
         this.firstOccurrence = firstOccurence;
+    }
+
+    public void setCloseTime(long closeTime) {
+        this.closeTime = closeTime;
+    }
+
+    public long getCloseTime() {
+        return closeTime;
     }
 
     public String getStateFieldValue() {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/MongoDedupEventsStore.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/MongoDedupEventsStore.java
@@ -16,20 +16,6 @@
  */
 package org.apache.eagle.alert.engine.publisher.dedup;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
-
-import org.apache.eagle.alert.engine.publisher.impl.EventUniq;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonInt64;
-import org.bson.BsonString;
-import org.bson.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.Block;
@@ -40,6 +26,15 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.typesafe.config.Config;
+import org.apache.eagle.alert.engine.publisher.impl.EventUniq;
+import org.bson.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class MongoDedupEventsStore implements DedupEventsStore {
 
@@ -47,6 +42,7 @@ public class MongoDedupEventsStore implements DedupEventsStore {
 
     public static final String DEDUP_ID = "dedupId";
     public static final String DEDUP_STREAM_ID = "streamId";
+    public static final String DOC_ID = "docId";
     public static final String DEDUP_POLICY_ID = "policyId";
     public static final String DEDUP_CREATE_TIME = "createdTime";
     public static final String DEDUP_TIMESTAMP = "timestamp";
@@ -56,6 +52,7 @@ public class MongoDedupEventsStore implements DedupEventsStore {
     public static final String DEDUP_STATE_FIELD_VALUE = "stateFieldValue";
     public static final String DEDUP_COUNT = "count";
     public static final String DEDUP_FIRST_OCCURRENCE = "firstOccurrence";
+    public static final String DEDUP_CLOSE_TIME = "closeTime";
     public static final String DEDUP_PUBLISH_ID = "publishId";
 
     private static final ObjectMapper mapper = new ObjectMapper();

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/TransformerUtils.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/dedup/TransformerUtils.java
@@ -16,18 +16,14 @@
  */
 package org.apache.eagle.alert.engine.publisher.dedup;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.eagle.alert.engine.publisher.impl.EventUniq;
+import org.bson.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
-
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.eagle.alert.engine.publisher.impl.EventUniq;
-import org.bson.BsonArray;
-import org.bson.BsonBoolean;
-import org.bson.BsonDocument;
-import org.bson.BsonInt64;
-import org.bson.BsonString;
 
 public class TransformerUtils {
 
@@ -64,6 +60,10 @@ public class TransformerUtils {
                     MongoDedupEventsStore.DEDUP_COUNT).getValue());
                 dedupValue.setFirstOccurrence(dedupValuesDoc.getInt64(
                     MongoDedupEventsStore.DEDUP_FIRST_OCCURRENCE).getValue());
+                dedupValue.setCloseTime(dedupValuesDoc.getInt64(
+                    MongoDedupEventsStore.DEDUP_CLOSE_TIME).getValue());
+                dedupValue.setDocId(dedupValuesDoc.getString(
+                    MongoDedupEventsStore.DOC_ID).getValue());
                 dedupValues.add(dedupValue);
             }
             String publishId = doc.getString(MongoDedupEventsStore.DEDUP_PUBLISH_ID).getValue();
@@ -96,12 +96,11 @@ public class TransformerUtils {
             List<BsonDocument> dedupValuesDocs = new ArrayList<BsonDocument>();
             for (DedupValue dedupValue : entity.getDedupValues()) {
                 BsonDocument dedupValuesDoc = new BsonDocument();
-                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_STATE_FIELD_VALUE,
-                    new BsonString(dedupValue.getStateFieldValue()));
-                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_COUNT,
-                    new BsonInt64(dedupValue.getCount()));
-                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_FIRST_OCCURRENCE,
-                    new BsonInt64(dedupValue.getFirstOccurrence()));
+                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_STATE_FIELD_VALUE, new BsonString(dedupValue.getStateFieldValue()));
+                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_COUNT, new BsonInt64(dedupValue.getCount()));
+                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_FIRST_OCCURRENCE,new BsonInt64(dedupValue.getFirstOccurrence()));
+                dedupValuesDoc.put(MongoDedupEventsStore.DEDUP_CLOSE_TIME, new BsonInt64(dedupValue.getCloseTime()));
+                dedupValuesDoc.put(MongoDedupEventsStore.DOC_ID, new BsonString(dedupValue.getDocId()));
                 dedupValuesDocs.add(dedupValuesDoc);
             }
             doc.put(MongoDedupEventsStore.DEDUP_VALUES, new BsonArray(dedupValuesDocs));

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
@@ -16,10 +16,8 @@
  */
 package org.apache.eagle.alert.engine.publisher.impl;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.base.Joiner;
+import com.typesafe.config.Config;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.eagle.alert.engine.codec.IEventSerializer;
 import org.apache.eagle.alert.engine.coordinator.OverrideDeduplicatorSpec;
@@ -31,8 +29,9 @@ import org.apache.eagle.alert.engine.publisher.dedup.DedupCache;
 import org.apache.eagle.alert.engine.publisher.dedup.ExtendedDeduplicator;
 import org.slf4j.Logger;
 
-import com.google.common.base.Joiner;
-import com.typesafe.config.Config;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @since Jun 3, 2016.
@@ -73,7 +72,7 @@ public abstract class AbstractPublishPlugin implements AlertPublishPlugin {
             }
         } else {
             this.deduplicator = new DefaultDeduplicator(publishment.getDedupIntervalMin(),
-                publishment.getDedupFields(), publishment.getDedupStateField(), dedupCache);
+                publishment.getDedupFields(), publishment.getDedupStateField(), publishment.getDedupStateCloseValue(), dedupCache);
             this.pubName = publishment.getName();
         }
         String serializerClz = publishment.getSerializer();

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/DefaultDeduplicator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/DefaultDeduplicator.java
@@ -17,12 +17,8 @@
  */
 package org.apache.eagle.alert.engine.publisher.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
 import org.apache.eagle.alert.engine.model.AlertStreamEvent;
@@ -32,8 +28,11 @@ import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultDeduplicator implements AlertDeduplicator {
 
@@ -42,6 +41,7 @@ public class DefaultDeduplicator implements AlertDeduplicator {
     private long dedupIntervalSec;
     private List<String> customDedupFields = new ArrayList<>();
     private String dedupStateField;
+    private String dedupStateCloseValue;
 
     private DedupCache dedupCache;
 
@@ -60,13 +60,16 @@ public class DefaultDeduplicator implements AlertDeduplicator {
     }
 
     public DefaultDeduplicator(String intervalMin, List<String> customDedupFields,
-                               String dedupStateField, DedupCache dedupCache) {
+                               String dedupStateField, String dedupStateCloseValue, DedupCache dedupCache) {
         setDedupIntervalMin(intervalMin);
         if (customDedupFields != null) {
             this.customDedupFields = customDedupFields;
         }
         if (StringUtils.isNotBlank(dedupStateField)) {
             this.dedupStateField = dedupStateField;
+        }
+        if (StringUtils.isNoneBlank(dedupStateCloseValue)) {
+            this.dedupStateCloseValue = dedupStateCloseValue;
         }
         this.dedupCache = dedupCache;
 
@@ -94,7 +97,7 @@ public class DefaultDeduplicator implements AlertDeduplicator {
             }
             return Arrays.asList(event);
         }
-        return dedupCache.dedup(event, key, dedupStateField, stateFiledValue);
+        return dedupCache.dedup(event, key, dedupStateField, stateFiledValue, dedupStateCloseValue);
     }
 
     public List<AlertStreamEvent> dedup(AlertStreamEvent event) {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DedupCacheStoreTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DedupCacheStoreTest.java
@@ -53,7 +53,7 @@ public class DedupCacheStoreTest extends MongoDependencyBaseTest {
 		System.setProperty("config.resource", "/application-mongo-statestore.conf");
 		Config config = ConfigFactory.load();
 		DedupCache cache = new DedupCache(config, "testPublishment");
-		cache.addOrUpdate(eventUniq, (String) event.getData()[event.getSchema().getColumnIndex("state")]);
+		cache.addOrUpdate(eventUniq, event, (String) event.getData()[event.getSchema().getColumnIndex("state")], "closed");
 		
 		DedupEventsStore accessor = DedupEventsStoreFactory.getStore(DedupEventsStoreType.Mongo, config, "testPublishment");
 		Map<EventUniq, ConcurrentLinkedDeque<DedupValue>> events = accessor.getEvents();

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DedupCacheTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DedupCacheTest.java
@@ -71,7 +71,7 @@ public class DedupCacheTest {
 			List<AlertStreamEvent> result = dedupCache.dedup(event, 
 					new EventUniq(event.getStreamId(), event.getPolicyId(), event.getCreatedTime(), dedupFieldValues), 
 					"state", 
-					(String) event.getData()[event.getSchema().getColumnIndex("state")]);
+					(String) event.getData()[event.getSchema().getColumnIndex("state")], "closed");
 			System.out.println((i + 1) + " >>>> " + ToStringBuilder.reflectionToString(result));
 		}
 		

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DefaultDedupWithoutStateTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DefaultDedupWithoutStateTest.java
@@ -44,7 +44,7 @@ public class DefaultDedupWithoutStateTest {
 		Config config = ConfigFactory.load();
 		DedupCache dedupCache = new DedupCache(config, "testPublishment");
 		DefaultDeduplicator deduplicator = new DefaultDeduplicator(
-				"PT10S", Arrays.asList(new String[] { "alertKey" }), null, dedupCache);
+				"PT10S", Arrays.asList(new String[] { "alertKey" }), null, null, dedupCache);
 		
 		StreamDefinition stream = createStream();
 		PolicyDefinition policy = createPolicy(stream.getStreamId(), "testPolicy");

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DefaultDeduplicatorTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/DefaultDeduplicatorTest.java
@@ -42,7 +42,7 @@ public class DefaultDeduplicatorTest extends MongoDependencyBaseTest {
 		Config config = ConfigFactory.load();
 		DedupCache dedupCache = new DedupCache(config, "testPublishment");
 		DefaultDeduplicator deduplicator = new DefaultDeduplicator(
-				"PT1M", Arrays.asList(new String[] { "alertKey" }), "state", dedupCache);
+				"PT1M", Arrays.asList(new String[] { "alertKey" }), "state", "close", dedupCache);
 		
 		StreamDefinition stream = createStream();
 		PolicyDefinition policy = createPolicy(stream.getStreamId(), "testPolicy");

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/MongoDedupStoreTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/MongoDedupStoreTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.eagle.alert.engine.publisher.dedup;
 
+import org.apache.eagle.alert.engine.publisher.impl.EventUniq;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentLinkedDeque;
-
-import org.apache.eagle.alert.engine.publisher.impl.EventUniq;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class MongoDedupStoreTest extends MongoDependencyBaseTest {
 
@@ -44,6 +44,8 @@ public class MongoDedupStoreTest extends MongoDependencyBaseTest {
 		DedupValue one = new DedupValue();
 		one.setStateFieldValue("OPEN");
 		one.setCount(2);
+		one.setCloseTime(0);
+		one.setDocId("doc-id-...");
 		one.setFirstOccurrence(System.currentTimeMillis());
 		dedupStateValues.add(one);
 		store.add(eventEniq, dedupStateValues);

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/TestDeduplicator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/dedup/TestDeduplicator.java
@@ -71,7 +71,7 @@ public class TestDeduplicator extends ExtendedDeduplicator {
         LOG.info("event key: " + eventkey);
         LOG.info("dedup field: " + this.getDedupStateField());
         LOG.info("dedup value: " + stateFiledValue);
-        List<AlertStreamEvent> result = this.getDedupCache().dedup(event, eventkey, this.getDedupStateField(), stateFiledValue);
+        List<AlertStreamEvent> result = this.getDedupCache().dedup(event, eventkey, this.getDedupStateField(), stateFiledValue, "closed");
         return result;
     }
 


### PR DESCRIPTION
AlertEngine : simplify state-based dedup to have only deupvalue for given dedup key
