### PR TITLE
EAGLE-594: Remove raw alert from kafka publisher

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/PublishConstants.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/PublishConstants.java
@@ -51,7 +51,4 @@ public class PublishConstants {
     public static final String ALERT_EMAIL_POLICY = "policyId";
     public static final String ALERT_EMAIL_CREATOR = "creator";
     
-    public static final String RAW_ALERT_NAMESPACE_LABEL = "rawAlertNamespaceLabel";
-    public static final String RAW_ALERT_NAMESPACE_VALUE = "rawAlertNamespaceValue";
-
 }


### PR DESCRIPTION
We are leveraging configured deduplicator to dedup the duplicated alerts before publish to kafka, email, slack, etc. However, sometimes we may still want to keep the raw alerts in kafka. Here we have defined rawAlertNamespaceLabel and rawAlertNamespaceValue custom fields to emit the raw alerts into kafka.
However, these configured namespace concept is ebay/sherlock specific, we should remove it from eagle and use it ebay/sherlock extended kafka publisher.