### PR TITLE
EAGLE-570: Refactor to make sure alert engine publisher only have gen…

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/resources/router/publishments-slack.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/resources/router/publishments-slack.json
@@ -8,8 +8,7 @@
     "properties": {
       "token": "your token",
       "channels": "your channel1, your channel2",
-      "severitys": "CRITICAL",
-      "urltemplate": "your template/?id=%s"
+      "severitys": "CRITICAL"
     },
     "dedupIntervalMin": "PT1M",
     "dedupFields": [


### PR DESCRIPTION
Eagle-567 intend to provide better formatting of slack channel message. But the implementation introduce too much specific logic (like defined field names) that beyond a common alerting engine should have.

So need to refactor to move the specific logic to either vendor specific extension or have configurable formatting.
