### PR TITLE
[EAGLE-597] Add API to filter publishment and single policy metadata by policyId

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/router/TestAlertBolt.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/router/TestAlertBolt.java
@@ -517,7 +517,7 @@ public class TestAlertBolt {
         Tuple input2 = new TupleImpl(context, Collections.singletonList(partitionedEvent2), taskId, "default");
         bolt.execute(input);
         bolt.execute(input2);
-        Assert.assertTrue("Timeout to acquire mutex in 5s", mutex.tryAcquire(1, 5, TimeUnit.SECONDS));
+        Assert.assertTrue("Timeout to acquire mutex in 10s", mutex.tryAcquire(1, 10, TimeUnit.SECONDS));
         Assert.assertEquals(3, alertCount.get());
         bolt.cleanup();
     }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/java/org/apache/eagle/service/metadata/resource/MetadataResource.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/java/org/apache/eagle/service/metadata/resource/MetadataResource.java
@@ -29,6 +29,7 @@ import com.google.inject.Inject;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.*;
 
 /**
@@ -44,7 +45,6 @@ public class MetadataResource {
 
     public MetadataResource() {
         this.dao = MetadataDaoFactory.getInstance().getMetadataDao();
-        ;
     }
 
     @Inject
@@ -210,6 +210,20 @@ public class MetadataResource {
     @DELETE
     public OpResult removePolicy(@PathParam("policyId") String policyId) {
         return dao.removePolicy(policyId);
+    }
+
+    @Path("/policies/{policyId}/publishments")
+    @GET
+    public List<Publishment> getPolicyPublishments(@PathParam("policyId") String policyId) {
+        return dao.listPublishment().stream().filter(ps ->
+            ps.getPolicyIds() != null && ps.getPolicyIds().contains(policyId)
+        ).collect(Collectors.toList());
+    }
+
+    @Path("/policies/{policyId}")
+    @GET
+    public List<PolicyDefinition> getPolicyByID(@PathParam("policyId") String policyId) {
+        return dao.listPolicies().stream().filter(pc -> pc.getName().equals(policyId)).collect(Collectors.toList());
     }
 
     @Path("/policies")


### PR DESCRIPTION
Alert engine publishments API only support to provide all publishments and let client-side to filter according requirements, which is NOT an scalable implementation.

As a quick solution to fix it in some way, we should provide a API to filter publishments by policy ID, so in this patch it mainly added two APIs:

* GET /metadata/policies/{policyId}
* GET /metadata/policies/{policyId}/publishments
