### PR TITLE
[EAGLE-598] Create 'ui' building profile and enable Eagle Web UI Building by default

### DIFF
--- a/eagle-server/pom.xml
+++ b/eagle-server/pom.xml
@@ -157,13 +157,43 @@
 
     <profiles>
         <profile>
+            <id>ui</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>exec-ui-install</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <arguments>
+                                        <argument>${basedir}/ui-build.sh</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>dev</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
 
             <!-- =========================================================================================================
-                 TODO: Decouple following specific application related dependencies into independent module: eagle-develop
+                 Following specific application related dependencies into independent module: eagle-develop
                  ========================================================================================================= -->
 
             <dependencies>
@@ -223,28 +253,16 @@
         </profile>
     </profiles>
     <build>
-        <!-- TODO: Temporarily disable ui-build.sh until INFRA-12669 was resolved -->
-        <!--<plugins>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>exec-maven-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>exec-ui-install</id>-->
-                        <!--<phase>generate-sources</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>exec</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<executable>bash</executable>-->
-                            <!--<arguments>-->
-                                <!--<argument>${basedir}/ui-build.sh</argument>-->
-                            <!--</arguments>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
-        <!--</plugins>-->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <failsOnError>true</failsOnError>
+                </configuration>
+            </plugin>
+        </plugins>
         <resources>
             <resource>
                 <directory>src/main/webapp/app/ui</directory>

--- a/eagle-server/src/main/java/org/apache/eagle/server/managedtask/ApplicationTask.java
+++ b/eagle-server/src/main/java/org/apache/eagle/server/managedtask/ApplicationTask.java
@@ -23,10 +23,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ApplicationTask implements Managed {
-    private final static Logger LOG = LoggerFactory.getLogger(ApplicationTask.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ApplicationTask.class);
     private final AbstractScheduledService service;
 
-    public ApplicationTask(AbstractScheduledService service){
+    public ApplicationTask(AbstractScheduledService service) {
         this.service = service;
     }
 

--- a/eagle-server/ui-build.sh
+++ b/eagle-server/ui-build.sh
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "=============== Web APP Building Start ==============="
+echo "=============== Building Web UI ==============="
+
 echo "Environment Check..."
 # Pre-build check
 if [ -z "$(command -v git)" ]
@@ -38,3 +39,5 @@ npm install
 # grunt build
 echo "building..."
 npm run build
+
+echo "=============== Finished ==============="

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
         <maven-source.version>3.0.0</maven-source.version>
         <maven-compiler.version>3.5.1</maven-compiler.version>
         <maven-dependency.version>2.10</maven-dependency.version>
+        <maven-exec.version>1.4.0</maven-exec.version>
         <maven-license.version>2.6</maven-license.version>
         <maven-surefire.version>2.6</maven-surefire.version>
         <maven-jar.version>2.6</maven-jar.version>
@@ -1108,6 +1109,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>${maven-assembly.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${maven-exec.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Create "ui" building profile and enable Eagle Web UI Building by default

    mvn clean install -DskipTests


Could also disable UI building with:

    mvn clean install -DskipTests -P!ui

Or (if "!" is reserved command in OS)

    mvn clean install -DskipTests -P\!ui
