### PR TITLE
EAGLE-602: Exception that Spec Version [xxx] of AlertBolt is newer th…

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/AlertBolt.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/AlertBolt.java
@@ -107,11 +107,12 @@ public class AlertBolt extends AbstractStreamBolt implements AlertBoltSpecListen
         try {
             PartitionedEvent pe = deserialize(input.getValueByField(AlertConstants.FIELD_0));
             String streamEventVersion = pe.getEvent().getMetaVersion();
-            if (streamEventVersion != null && !streamEventVersion.equals(specVersion)) {
-                if (streamEventVersion == null) {
-                    // if stream event version is null, need to initialize it
-                    pe.getEvent().setMetaVersion(specVersion);
-                } else if (specVersion != null && streamEventVersion != null
+
+            if (streamEventVersion == null) {
+                // if stream event version is null, need to initialize it
+                pe.getEvent().setMetaVersion(specVersion);
+            } else if (streamEventVersion != null && !streamEventVersion.equals(specVersion)) {
+                if (specVersion != null && streamEventVersion != null
                     && specVersion.contains("spec_version_") && streamEventVersion.contains("spec_version_")) {
                     // check if specVersion is older than stream_event_version
                     // Long timestamp_of_specVersion = Long.valueOf(specVersion.split("spec_version_")[1]);

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/serialization/impl/StreamEventSerializer.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/serialization/impl/StreamEventSerializer.java
@@ -89,6 +89,12 @@ public class StreamEventSerializer implements Serializer<StreamEvent> {
         String metaVersionStreamId = dataInput.readUTF();
         String streamId = metaVersionStreamId.split("/")[1];
         String metaVersion = metaVersionStreamId.split("/")[0];
+        // sometimes metaVersionStreamId will be "null/id", then metaVersion will be "null" rather than null
+        // need to handle it for future use
+        if (metaVersion.equals("null")) {
+            metaVersion = null;
+        }
+
         event.setStreamId(streamId);
         event.setMetaVersion(metaVersion);
 


### PR DESCRIPTION
Just find exception as below:
2016-10-06 22:51:41 org.apache.eagle.alert.engine.runner.AlertBolt [WARN] Spec Version [spec_version_1475817732537] of AlertBolt is newer than Stream Event Version [null]!

Seems there's an error when get meta version from stream event or initialising failed when stream event version is null.