### PR TITLE
[EAGLE-562] added metrics associated with virtual-cores involved since hadoop 2.7.x

### DIFF
--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/common/HadoopClusterConstants.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/common/HadoopClusterConstants.java
@@ -44,6 +44,7 @@ public class HadoopClusterConstants {
         public static final String HADOOP_CLUSTER_TOTAL_MEMORY = "hadoop.cluster.totalmemory";
         public static final String HADOOP_CLUSTER_AVAILABLE_MEMORY = "hadoop.cluster.availablememory";
         public static final String HADOOP_CLUSTER_RESERVED_MEMORY = "hadoop.cluster.reservedmemory";
+        public static final String HADOOP_CLUSTER_TOTAL_VIRTUAL_CORES = "hadoop.cluster.totalvirtualcores";
 
         // metrics from scheduler info
         public static final String HADOOP_CLUSTER_CAPACITY = "hadoop.cluster.capacity";

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/crawler/ClusterMetricsParseListener.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/crawler/ClusterMetricsParseListener.java
@@ -83,6 +83,7 @@ public class ClusterMetricsParseListener {
         createMetric(MetricName.HADOOP_CLUSTER_TOTAL_MEMORY, currentTimestamp, metrics.getTotalMB(), AggregateFunc.MAX);
         createMetric(MetricName.HADOOP_CLUSTER_AVAILABLE_MEMORY, currentTimestamp, metrics.getAvailableMB(), AggregateFunc.AVG);
         createMetric(MetricName.HADOOP_CLUSTER_RESERVED_MEMORY, currentTimestamp, metrics.getReservedMB(), AggregateFunc.AVG);
+        createMetric(MetricName.HADOOP_CLUSTER_TOTAL_VIRTUAL_CORES, currentTimestamp, metrics.getTotalVirtualCores(), AggregateFunc.MAX);
     }
 
     public void flush() {

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/cluster/ClusterMetrics.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/cluster/ClusterMetrics.java
@@ -44,6 +44,15 @@ public class ClusterMetrics {
     private int rebootedNodes;
     private int activeNodes;
 
+    // available in hadoop 2.7.x or higher
+    private long totalVirtualCores;
+    // available in hadoop 2.7.x or higher
+    private long reservedVirtualCores;
+    // available in hadoop 2.7.x or higher
+    private long availableVirtualCores;
+    // available in hadoop 2.7.x or higher
+    private long allocatedVirtualCores;
+
     public int getAppsSubmitted() {
         return appsSubmitted;
     }
@@ -194,5 +203,37 @@ public class ClusterMetrics {
 
     public void setActiveNodes(int activeNodes) {
         this.activeNodes = activeNodes;
+    }
+
+    public long getTotalVirtualCores() {
+        return totalVirtualCores;
+    }
+
+    public void setTotalVirtualCores(long totalVirtualCores) {
+        this.totalVirtualCores = totalVirtualCores;
+    }
+
+    public long getReservedVirtualCores() {
+        return reservedVirtualCores;
+    }
+
+    public void setReservedVirtualCores(long reservedVirtualCores) {
+        this.reservedVirtualCores = reservedVirtualCores;
+    }
+
+    public long getAvailableVirtualCores() {
+        return availableVirtualCores;
+    }
+
+    public void setAvailableVirtualCores(long availableVirtualCores) {
+        this.availableVirtualCores = availableVirtualCores;
+    }
+
+    public long getAllocatedVirtualCores() {
+        return allocatedVirtualCores;
+    }
+
+    public void setAllocatedVirtualCores(long allocatedVirtualCores) {
+        this.allocatedVirtualCores = allocatedVirtualCores;
     }
 }


### PR DESCRIPTION
add 4 virtual-cores related metrics involved since hadoop 2.7.x to ClusterMetrics
   - totalVirtualCores, reservedVirtualCores, availableVirtualCores, allocatedVirtualCores
   - in this commit, only totalVirtualCores is included to be listened