### PR TITLE
EAGLE-614: NPE in DynamicPolicyLoader

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PolicyDefinition.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PolicyDefinition.java
@@ -139,15 +139,18 @@ public class PolicyDefinition implements Serializable {
         if (that == this) {
             return true;
         }
+
         if (!(that instanceof PolicyDefinition)) {
             return false;
         }
+
         PolicyDefinition another = (PolicyDefinition) that;
+
         if (Objects.equals(another.name, this.name)
             && Objects.equals(another.description, this.description)
             && CollectionUtils.isEqualCollection(another.inputStreams, this.inputStreams)
             && CollectionUtils.isEqualCollection(another.outputStreams, this.outputStreams)
-            && another.definition.equals(this.definition)
+            && (another.definition != null && another.definition.equals(this.definition))
             && Objects.equals(this.definition, another.definition)
             && CollectionUtils.isEqualCollection(another.partitionSpec, this.partitionSpec)
             // && another.parallelismHint == this.parallelismHint

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/trigger/DynamicPolicyLoader.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/trigger/DynamicPolicyLoader.java
@@ -66,7 +66,8 @@ public class DynamicPolicyLoader implements Runnable {
 
             List<String> reallyModifiedPolicies = new ArrayList<>();
             for (String updatedPolicy : potentiallyModifiedPolicies) {
-                if (!currPolicies.get(updatedPolicy).equals(cachedPolicies.get(updatedPolicy))) {
+                if (currPolicies.get(updatedPolicy) != null
+                        && !currPolicies.get(updatedPolicy).equals(cachedPolicies.get(updatedPolicy))) {
                     reallyModifiedPolicies.add(updatedPolicy);
                 }
             }


### PR DESCRIPTION
Find exception as below:
INFO [2016-10-13 01:15:02,965] org.apache.eagle.alert.coordinator.trigger.DynamicPolicyLoader: policies loader start.
INFO [2016-10-13 01:15:02,966] org.apache.eagle.alert.service.MetadataServiceClientImpl: query URL http://localhost:8080/rest/metadata/policies
ERROR [2016-10-13 01:15:02,972] org.apache.eagle.alert.coordinator.trigger.DynamicPolicyLoader: error loading policy, but continue to run
! java.lang.NullPointerException: null
! at org.apache.eagle.alert.engine.coordinator.PolicyDefinition.equals(PolicyDefinition.java:150) ~[alert-service-0.5.0-incubating-SNAPSHOT-shaded.jar
:0.5.0-incubating-SNAPSHOT]
! at org.apache.eagle.alert.coordinator.trigger.DynamicPolicyLoader.run(DynamicPolicyLoader.java:69) ~[alert-service-0.5.0-incubating-SNAPSHOT-shaded.
jar:0.5.0-incubating-SNAPSHOT]
! at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_102]
! at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_102]
! at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_102]
! at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_102]
! at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_102]
! at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_102]
! at java.lang.Thread.run(Thread.java:745) [na:1.8.0_102]
we have compare null with other object which should be avoided.