### PR TITLE
[EAGLE-616] AlertEngine: Reduce the connection from alert-service to ZK

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/Coordinator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/Coordinator.java
@@ -185,6 +185,7 @@ public class Coordinator {
         for (String topo : state.getPublishSpecs().keySet()) {
             producer.send(MessageFormat.format(ZK_ALERT_CONFIG_PUBLISHER, topo), value);
         }
+
     }
 
     public ScheduleState getState() {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/trigger/CoordinatorTrigger.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/trigger/CoordinatorTrigger.java
@@ -65,8 +65,10 @@ public class CoordinatorTrigger implements Runnable {
 
                 ScheduleState state = scheduler.schedule(new ScheduleOption());
 
-                ConfigBusProducer producer = new ConfigBusProducer(ZKConfigBuilder.getZKConfig(config));
-                Coordinator.postSchedule(client, state, producer);
+                // use try catch to use AutoCloseable interface to close producer automatically
+                try (ConfigBusProducer producer = new ConfigBusProducer(ZKConfigBuilder.getZKConfig(config))) {
+                    Coordinator.postSchedule(client, state, producer);
+                }
 
                 watch.stop();
                 LOG.info("CoordinatorTrigger ended, used time {} sm.", watch.elapsed(TimeUnit.MILLISECONDS));


### PR DESCRIPTION
In QA, it used to show too much connection from alert-service to zookeeper.
We only use zk for exclusive lock and spec version notify, should not have so much connection.