### PR TITLE
[EAGLE-620]: AlertEngine: SpoutWrapper are sending duplicated message

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/impl/MonitorMetadataGenerator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/impl/MonitorMetadataGenerator.java
@@ -265,7 +265,7 @@ public class MonitorMetadataGenerator {
             }
         }
         if (targetSm == null) {
-            targetSm = new StreamRepartitionMetadata(datasourceName, schema.getStreamId());
+            targetSm = new StreamRepartitionMetadata(topicName, schema.getStreamId());
             dsStreamMeta.add(targetSm);
         }
         if (!targetSm.groupingStrategies.contains(gs)) {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/spout/SpoutOutputCollectorWrapper.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/spout/SpoutOutputCollectorWrapper.java
@@ -18,6 +18,9 @@
  */
 package org.apache.eagle.alert.engine.spout;
 
+import backtype.storm.spout.ISpoutOutputCollector;
+import backtype.storm.spout.SpoutOutputCollector;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.eagle.alert.coordination.model.SpoutSpec;
 import org.apache.eagle.alert.coordination.model.StreamRepartitionMetadata;
 import org.apache.eagle.alert.coordination.model.StreamRepartitionStrategy;
@@ -29,9 +32,6 @@ import org.apache.eagle.alert.engine.model.StreamEvent;
 import org.apache.eagle.alert.engine.serialization.PartitionedEventSerializer;
 import org.apache.eagle.alert.engine.serialization.SerializationMetadataProvider;
 import org.apache.eagle.alert.utils.StreamIdConversion;
-import backtype.storm.spout.ISpoutOutputCollector;
-import backtype.storm.spout.SpoutOutputCollector;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +121,9 @@ public class SpoutOutputCollectorWrapper extends SpoutOutputCollector implements
             phase 2: stream repartition
         */
         for (StreamRepartitionMetadata md : streamRepartitionMetadataList) {
+            if (!event.getStreamId().equals(md.getStreamId())) {
+                continue;
+            }
             // one stream may have multiple group-by strategies, each strategy is for a specific group-by
             for (StreamRepartitionStrategy groupingStrategy : md.groupingStrategies) {
                 int hash = 0;


### PR DESCRIPTION
An event of stream id "ncAlertOutputStream" will be send three times given below spec:

process.network.alerts: [
{
topicName: "network_aggregate_alert_output_datasource",
streamId: "ncAlertOutputStream",
groupingStrategies: [
{
partition: {
streamId: "ncAlertOutputStream",
type: "GROUPBY",
columns: [
"entity"
]
},
numTotalParticipatingRouterBolts: 4,
startSequence: 0,
totalTargetBoltIds: [
"streamRouterBolt0",
"streamRouterBolt1",
"streamRouterBolt2",
"streamRouterBolt3"
]
}
]
},
{
topicName: "network_aggregate_alert_output_datasource",
streamId: "sherlockAlertOutputStream",
groupingStrategies: [
{
partition: {
streamId: "sherlockAlertOutputStream",
type: "GROUPBY",
columns: [
"entity"
]
},
numTotalParticipatingRouterBolts: 4,
startSequence: 0,
totalTargetBoltIds: [
"streamRouterBolt0",
"streamRouterBolt1",
"streamRouterBolt2",
"streamRouterBolt3"
]
}
]
},
{
topicName: "network_aggregate_alert_output_datasource",
streamId: "correlatedAlertStream",
groupingStrategies: [
{
partition: {
streamId: "correlatedAlertStream",
type: "GROUPBY",
columns: [
"linkedSwitch"
]
},
numTotalParticipatingRouterBolts: 4,
startSequence: 0,
totalTargetBoltIds: [
"streamRouterBolt0",
"streamRouterBolt1",
"streamRouterBolt2",
"streamRouterBolt3"
]
}
]
}
],

The root cause is in SpoutOutputCollectorWrapper.emit() the streamId of group strategy is not compared with the given stream event.

Author: ralphsu

This closes