### PR TITLE
EAGLE-641: Publishment reload may introduce NPE

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertKafkaPublisher.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertKafkaPublisher.java
@@ -75,7 +75,9 @@ public class AlertKafkaPublisher extends AbstractPublishPlugin {
         String newBrokerList = pluginProperties.get(PublishConstants.BROKER_LIST).trim();
         String newTopic = pluginProperties.get(PublishConstants.TOPIC).trim();
         if (!newBrokerList.equals(this.brokerList)) {
-            producer.close();
+            if (producer != null) {
+                producer.close();
+            }
             brokerList = newBrokerList;
             KafkaProducer newProducer = null;
             try {


### PR DESCRIPTION
The publishment initialization may have problem which will cause reload NPE.