### PR TITLE
EAGLE-646: AlertUnitTopology does not rebuild the scheduler state after restarting	

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert-app/pom.xml
+++ b/eagle-core/eagle-alert-parent/eagle-alert-app/pom.xml
@@ -31,5 +31,10 @@
       <artifactId>eagle-app-base</artifactId>
       <version>${project.version}</version>
     </dependency>
+      <dependency>
+          <groupId>org.apache.eagle</groupId>
+          <artifactId>alert-coordinator</artifactId>
+          <version>${project.version}</version>
+      </dependency>
   </dependencies>
 </project>

--- a/eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertUnitTopologyAppListener.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertUnitTopologyAppListener.java
@@ -18,6 +18,7 @@
 package org.apache.eagle.alert.app;
 
 import org.apache.eagle.alert.coordination.model.internal.Topology;
+import org.apache.eagle.alert.coordinator.Coordinator;
 import org.apache.eagle.alert.engine.runner.UnitTopologyRunner;
 import org.apache.eagle.alert.metadata.IMetadataDao;
 import org.apache.eagle.alert.metadata.resource.OpResult;
@@ -73,6 +74,7 @@ class AlertUnitTopologyAppListener implements ApplicationListener {
             LOG.error(result.message);
             throw new IllegalStateException(result.message);
         }
+        Coordinator.startSchedule();
     }
 
     private void removeTopologyMetadata() {

--- a/eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertUnitTopologyAppListener.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertUnitTopologyAppListener.java
@@ -18,7 +18,7 @@
 package org.apache.eagle.alert.app;
 
 import org.apache.eagle.alert.coordination.model.internal.Topology;
-import org.apache.eagle.alert.coordinator.Coordinator;
+import org.apache.eagle.alert.coordinator.resource.CoordinatorResource;
 import org.apache.eagle.alert.engine.runner.UnitTopologyRunner;
 import org.apache.eagle.alert.metadata.IMetadataDao;
 import org.apache.eagle.alert.metadata.resource.OpResult;
@@ -34,6 +34,7 @@ class AlertUnitTopologyAppListener implements ApplicationListener {
     private static final Logger LOG = LoggerFactory.getLogger(AlertUnitTopologyAppListener.class);
 
     @Inject private IMetadataDao metadataDao;
+    @Inject private CoordinatorResource coordinatorResource;
 
     private ApplicationEntity applicationEntity;
 
@@ -74,7 +75,11 @@ class AlertUnitTopologyAppListener implements ApplicationListener {
             LOG.error(result.message);
             throw new IllegalStateException(result.message);
         }
-        Coordinator.startSchedule();
+        try {
+            coordinatorResource.build();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
     }
 
     private void removeTopologyMetadata() {

--- a/eagle-core/eagle-data-process/src/main/java/org/apache/eagle/dataproc/impl/storm/kafka/KafkaSpoutProvider.java
+++ b/eagle-core/eagle-data-process/src/main/java/org/apache/eagle/dataproc/impl/storm/kafka/KafkaSpoutProvider.java
@@ -60,7 +60,7 @@ public class KafkaSpoutProvider implements StormSpoutProvider {
         // Kafka broker zk connection
         String zkConnString = context.getString("zkConnection");
         // Kafka fetch size
-        int fetchSize = context.hasPath("fetchSize") ? context.getInt("fetchSize") : 1048586;
+        int fetchSize = context.hasPath("fetchSize") ? context.getInt("fetchSize") : 1048576;
         LOG.info(String.format("Use topic : %s, zkConnection : %s , fetchSize : %d", topic, zkConnString, fetchSize));
 
         /*
@@ -97,6 +97,8 @@ public class KafkaSpoutProvider implements StormSpoutProvider {
         spoutConfig.stateUpdateIntervalMs = context.hasPath("transactionStateUpdateMS") ? context.getLong("transactionStateUpdateMS") : 2000;
         // Kafka fetch size
         spoutConfig.fetchSizeBytes = fetchSize;
+        spoutConfig.startOffsetTime = kafka.api.OffsetRequest.LatestTime();
+
         // "startOffsetTime" is for test usage, prod should not use this
         if (context.hasPath("startOffsetTime")) {
             spoutConfig.startOffsetTime = context.getInt("startOffsetTime");

--- a/eagle-topology-assembly/pom.xml
+++ b/eagle-topology-assembly/pom.xml
@@ -45,32 +45,11 @@
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-server</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.eagle</groupId>
-            <artifactId>eagle-jpm-mr-history</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.eagle</groupId>
-            <artifactId>eagle-jpm-mr-running</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.eagle</groupId>
-            <artifactId>eagle-jpm-web</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.eagle</groupId>
-            <artifactId>eagle-jpm-aggregation</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.eagle</groupId>
-            <artifactId>eagle-hadoop-queue</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/eagle-topology-assembly/src/resources/META-INF/services/org.apache.eagle.app.spi.ApplicationProvider
+++ b/eagle-topology-assembly/src/resources/META-INF/services/org.apache.eagle.app.spi.ApplicationProvider
@@ -13,8 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+org.apache.eagle.alert.app.AlertUnitTopologyAppProvider
+
+## DAM
 org.apache.eagle.security.hbase.HBaseAuditLogAppProvider
-org.apache.eagle.app.example.ExampleApplicationProvider
+org.apache.eagle.security.auditlog.HdfsAuditLogAppProvider
+
+## JPM
 org.apache.eagle.app.jpm.JPMWebApplicationProvider
 org.apache.eagle.jpm.mr.history.MRHistoryJobApplicationProvider
 org.apache.eagle.jpm.mr.running.MRRunningJobApplicationProvider


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-646

1. Fix a bug that alertUnitTopology does not rebuild the scheduler state after restarting
2. Fix topology assembly dependency bug	
