### PR TITLE
EAGLE-660 : Stream delete mongo implementation is not working

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/main/java/org/apache/eagle/alert/metadata/impl/MongoMetadataDaoImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/main/java/org/apache/eagle/alert/metadata/impl/MongoMetadataDaoImpl.java
@@ -16,16 +16,6 @@
  */
 package org.apache.eagle.alert.metadata.impl;
 
-import org.apache.eagle.alert.coordination.model.*;
-import org.apache.eagle.alert.coordination.model.internal.MonitoredStream;
-import org.apache.eagle.alert.coordination.model.internal.PolicyAssignment;
-import org.apache.eagle.alert.coordination.model.internal.ScheduleStateBase;
-import org.apache.eagle.alert.coordination.model.internal.Topology;
-import org.apache.eagle.alert.engine.coordinator.*;
-import org.apache.eagle.alert.metadata.IMetadataDao;
-import org.apache.eagle.alert.metadata.MetadataUtils;
-import org.apache.eagle.alert.metadata.resource.Models;
-import org.apache.eagle.alert.metadata.resource.OpResult;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
@@ -40,6 +30,16 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import com.typesafe.config.Config;
+import org.apache.eagle.alert.coordination.model.*;
+import org.apache.eagle.alert.coordination.model.internal.MonitoredStream;
+import org.apache.eagle.alert.coordination.model.internal.PolicyAssignment;
+import org.apache.eagle.alert.coordination.model.internal.ScheduleStateBase;
+import org.apache.eagle.alert.coordination.model.internal.Topology;
+import org.apache.eagle.alert.engine.coordinator.*;
+import org.apache.eagle.alert.metadata.IMetadataDao;
+import org.apache.eagle.alert.metadata.MetadataUtils;
+import org.apache.eagle.alert.metadata.resource.Models;
+import org.apache.eagle.alert.metadata.resource.OpResult;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
@@ -205,8 +205,12 @@ public class MongoMetadataDaoImpl implements IMetadataDao {
     }
 
     private <T> OpResult remove(MongoCollection<Document> collection, String name) {
+        return removeObject(collection, "name", name);
+    }
+
+    private <T> OpResult removeObject(MongoCollection<Document> collection, String nameField, String name) {
         BsonDocument filter = new BsonDocument();
-        filter.append("name", new BsonString(name));
+        filter.append(nameField, new BsonString(name));
         DeleteResult dr = collection.deleteOne(filter);
         OpResult result = new OpResult();
         result.code = 200;
@@ -236,7 +240,7 @@ public class MongoMetadataDaoImpl implements IMetadataDao {
 
     @Override
     public OpResult removeStream(String streamId) {
-        return remove(schema, streamId);
+        return removeObject(schema, "streamId", streamId);
     }
 
     @Override

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/service/alert/resource/impl/MongoImplTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/service/alert/resource/impl/MongoImplTest.java
@@ -194,6 +194,18 @@ public class MongoImplTest {
             ScheduleState getState = dao.getScheduleState();
             Assert.assertEquals(201, getState.getCode());
         }
+        // stream
+        {
+            StreamDefinition stream = new StreamDefinition();
+            stream.setStreamId("stream");
+            OpResult result = dao.createStream(stream);
+            Assert.assertEquals(200, result.code);
+            List<StreamDefinition> assigns = dao.listStreams();
+            Assert.assertEquals(1, assigns.size());
+            dao.removeStream("stream");
+            assigns = dao.listStreams();
+            Assert.assertEquals(0, assigns.size());
+        }
     }
 
     private void test_addstate() {


### PR DESCRIPTION

The streamDefiniton use streamId instead of name, while the delete stream use "name" to find and delete, this cause the delete stream failed.

Add and update stream is ok.

Reporter: Li, Garrett
Author: Li, Garrett
Reviewer: ralphsu