### PR TITLE
EAGLE-670: make kafka publisher configurable and default is async

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
@@ -37,7 +37,7 @@ public class Publishment {
     private String dedupStateField;
     private String dedupStateCloseValue;
     private OverrideDeduplicatorSpec overrideDeduplicator;
-    private Map<String, String> properties;
+    private Map<String, Object> properties;
     // the class name to extend the IEventSerializer interface
     private String serializer;
 
@@ -113,11 +113,11 @@ public class Publishment {
         this.dedupFields = dedupFields;
     }
 
-    public Map<String, String> getProperties() {
+    public Map<String, Object> getProperties() {
         return properties;
     }
 
-    public void setProperties(Map<String, String> properties) {
+    public void setProperties(Map<String, Object> properties) {
         this.properties = properties;
     }
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/provider/NodataMetadataGenerator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/provider/NodataMetadataGenerator.java
@@ -268,7 +268,7 @@ public class NodataMetadataGenerator {
         publishment.setType(KAFKA_PUBLISHMENT_TYPE);
         publishment.setPolicyIds(Arrays.asList(policyName));
         publishment.setDedupIntervalMin(PUBLISHMENT_DEDUP_DURATION);
-        Map<String, String> publishmentProperties = new HashMap<String, String>();
+        Map<String, Object> publishmentProperties = new HashMap<>();
         publishmentProperties.put("kafka_broker", kafkaBroker);
         publishmentProperties.put("topic", topic);
         publishment.setProperties(publishmentProperties);
@@ -283,7 +283,7 @@ public class NodataMetadataGenerator {
         publishment.setType(EMAIL_PUBLISHMENT_TYPE);
         publishment.setPolicyIds(Arrays.asList(policyName));
         publishment.setDedupIntervalMin(PUBLISHMENT_DEDUP_DURATION);
-        Map<String, String> publishmentProperties = new HashMap<String, String>();
+        Map<String, Object> publishmentProperties = new HashMap<>();
         publishmentProperties.put("subject", String.format("Eagle Alert - %s", topic));
         publishmentProperties.put("template", "");
         publishmentProperties.put("sender", config.getString("email.sender"));

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/AlertPublishPlugin.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/AlertPublishPlugin.java
@@ -24,10 +24,8 @@ import java.util.Map;
 import org.apache.eagle.alert.engine.coordinator.Publishment;
 import org.apache.eagle.alert.engine.model.AlertStreamEvent;
 import org.apache.eagle.alert.engine.publisher.impl.PublishStatus;
-import com.typesafe.config.Config;
 
-import java.io.Closeable;
-import java.util.Map;
+import com.typesafe.config.Config;
 
 /**
  * Created on 2/10/16.
@@ -45,7 +43,7 @@ public interface AlertPublishPlugin extends Closeable {
     @SuppressWarnings("rawtypes")
     void init(Config config, Publishment publishment, Map configProperties) throws Exception;
 
-    void update(String dedupIntervalMin, Map<String, String> pluginProperties);
+    void update(String dedupIntervalMin, Map<String, Object> pluginProperties);
 
     void close();
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/PublishConstants.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/PublishConstants.java
@@ -33,6 +33,7 @@ public class PublishConstants {
     // kafka specific constants
     public static final String TOPIC = "topic";
     public static final String BROKER_LIST = "kafka_broker";
+    public static final String WRITE_MODE = "kafka_write_mode";
 
     // slack specific constants
     public static final String TOKEN = "token";
@@ -50,5 +51,5 @@ public class PublishConstants {
     public static final String ALERT_EMAIL_TIMESTAMP = "alertTime";
     public static final String ALERT_EMAIL_POLICY = "policyId";
     public static final String ALERT_EMAIL_CREATOR = "creator";
-    
+
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/email/AlertEmailGenerator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/email/AlertEmailGenerator.java
@@ -35,7 +35,7 @@ public class AlertEmailGenerator {
     private String sender;
     private String recipients;
     private String subject;
-    private Map<String, String> properties;
+    private Map<String, Object> properties;
 
     private ThreadPoolExecutor executorPool;
 
@@ -127,11 +127,11 @@ public class AlertEmailGenerator {
         this.subject = subject;
     }
 
-    public Map<String, String> getProperties() {
+    public Map<String, Object> getProperties() {
         return properties;
     }
 
-    public void setProperties(Map<String, String> properties) {
+    public void setProperties(Map<String, Object> properties) {
         this.properties = properties;
     }
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/email/AlertEmailGeneratorBuilder.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/email/AlertEmailGeneratorBuilder.java
@@ -51,7 +51,7 @@ public class AlertEmailGeneratorBuilder {
         return this;
     }
 
-    public AlertEmailGeneratorBuilder withMailProps(Map<String, String> mailProps) {
+    public AlertEmailGeneratorBuilder withMailProps(Map<String, Object> mailProps) {
         generator.setProperties(mailProps);
         return this;
     }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/email/AlertEmailSender.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/email/AlertEmailSender.java
@@ -44,7 +44,7 @@ public class AlertEmailSender implements Runnable {
     private static final int MAX_RETRY_COUNT = 3;
 
 
-    private Map<String, String> mailProps;
+    private Map<String, Object> mailProps;
 
 
     private String threadName;
@@ -73,18 +73,18 @@ public class AlertEmailSender implements Runnable {
         LOG.info("Initialized " + threadName + ": origin is : " + this.origin + ", recipient of the email: " + this.recipients + ", velocity TPL file: " + this.configFileName);
     }
 
-    public AlertEmailSender(AlertEmailContext alertEmail, Map<String, String> mailProps) {
+    public AlertEmailSender(AlertEmailContext alertEmail, Map<String, Object> mailProps) {
         this(alertEmail);
         this.mailProps = mailProps;
     }
 
-    private Properties parseMailClientConfig(Map<String, String> mailProps) {
+    private Properties parseMailClientConfig(Map<String, Object> mailProps) {
         if (mailProps == null) {
             return null;
         }
         Properties props = new Properties();
-        String mailHost = mailProps.get(AlertEmailConstants.CONF_MAIL_HOST);
-        String mailPort = mailProps.get(AlertEmailConstants.CONF_MAIL_PORT);
+        String mailHost = (String) mailProps.get(AlertEmailConstants.CONF_MAIL_HOST);
+        String mailPort = (String) mailProps.get(AlertEmailConstants.CONF_MAIL_PORT);
         if (mailHost == null || mailPort == null || mailHost.isEmpty()) {
             LOG.warn("SMTP server is unset, will exit");
             return null;
@@ -92,14 +92,14 @@ public class AlertEmailSender implements Runnable {
         props.put(AlertEmailConstants.CONF_MAIL_HOST, mailHost);
         props.put(AlertEmailConstants.CONF_MAIL_PORT, mailPort);
 
-        String smtpAuth = mailProps.getOrDefault(AlertEmailConstants.CONF_MAIL_AUTH, "false");
+        String smtpAuth = (String) mailProps.getOrDefault(AlertEmailConstants.CONF_MAIL_AUTH, "false");
         props.put(AlertEmailConstants.CONF_MAIL_AUTH, smtpAuth);
         if (Boolean.parseBoolean(smtpAuth)) {
             props.put(AlertEmailConstants.CONF_AUTH_USER, mailProps.get(AlertEmailConstants.CONF_AUTH_USER));
             props.put(AlertEmailConstants.CONF_AUTH_PASSWORD, mailProps.get(AlertEmailConstants.CONF_AUTH_PASSWORD));
         }
 
-        String smtpConn = mailProps.getOrDefault(AlertEmailConstants.CONF_MAIL_CONN, AlertEmailConstants.CONN_PLAINTEXT);
+        String smtpConn = (String) mailProps.getOrDefault(AlertEmailConstants.CONF_MAIL_CONN, AlertEmailConstants.CONN_PLAINTEXT);
         if (smtpConn.equalsIgnoreCase(AlertEmailConstants.CONN_TLS)) {
             props.put("mail.smtp.starttls.enable", "true");
         }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
@@ -92,7 +92,7 @@ public abstract class AbstractPublishPlugin implements AlertPublishPlugin {
     }
 
     @Override
-    public void update(String dedupIntervalMin, Map<String, String> pluginProperties) {
+    public void update(String dedupIntervalMin, Map<String, Object> pluginProperties) {
         deduplicator.setDedupIntervalMin(dedupIntervalMin);
     }
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertEmailPublisher.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertEmailPublisher.java
@@ -43,7 +43,7 @@ public class AlertEmailPublisher extends AbstractPublishPlugin {
     private static final long DEFAULT_THREAD_POOL_SHRINK_TIME = 60000L; // 1 minute
 
     private AlertEmailGenerator emailGenerator;
-    private Map<String, String> emailConfig;
+    private Map<String, Object> emailConfig;
 
     private transient ThreadPoolExecutor executorPool;
 
@@ -88,7 +88,7 @@ public class AlertEmailPublisher extends AbstractPublishPlugin {
     }
 
     @Override
-    public void update(String dedupIntervalMin, Map<String, String> pluginProperties) {
+    public void update(String dedupIntervalMin, Map<String, Object> pluginProperties) {
         super.update(dedupIntervalMin, pluginProperties);
 
         if (pluginProperties != null && !emailConfig.equals(pluginProperties)) {
@@ -102,17 +102,17 @@ public class AlertEmailPublisher extends AbstractPublishPlugin {
         this.executorPool.shutdown();
     }
 
-    private AlertEmailGenerator createEmailGenerator(Map<String, String> notificationConfig) {
-        String tplFileName = notificationConfig.get(PublishConstants.TEMPLATE);
+    private AlertEmailGenerator createEmailGenerator(Map<String, Object> notificationConfig) {
+        String tplFileName = (String) notificationConfig.get(PublishConstants.TEMPLATE);
         if (tplFileName == null || tplFileName.equals("")) {
             tplFileName = "ALERT_DEFAULT.vm";
         }
-        String subject = notificationConfig.get(PublishConstants.SUBJECT);
+        String subject = (String) notificationConfig.get(PublishConstants.SUBJECT);
         if (subject == null) {
             subject = "No subject";
         }
-        String sender = notificationConfig.get(PublishConstants.SENDER);
-        String recipients = notificationConfig.get(PublishConstants.RECIPIENTS);
+        String sender = (String) notificationConfig.get(PublishConstants.SENDER);
+        String recipients = (String) notificationConfig.get(PublishConstants.RECIPIENTS);
         if (sender == null || recipients == null) {
             LOG.warn("email sender or recipients is null");
             return null;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertKafkaPublisher.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertKafkaPublisher.java
@@ -54,14 +54,11 @@ public class AlertKafkaPublisher extends AbstractPublishPlugin {
         super.init(config, publishment, conf);
 
         if (publishment.getProperties() != null) {
-            Map<String, String> kafkaConfig = new HashMap<>(publishment.getProperties());
-            brokerList = kafkaConfig.get(PublishConstants.BROKER_LIST).trim();
-            producer = KafkaProducerManager.INSTANCE.getProducer(brokerList, kafkaConfig);
-            topic = kafkaConfig.get(PublishConstants.TOPIC).trim();
-            String writeMode = kafkaConfig.get(PublishConstants.WRITE_MODE);
-            if (writeMode != null) {
-                mode = KafkaWriteMode.fromString(writeMode);
-            }
+            Map<String, Object> publishConfig = new HashMap<>(publishment.getProperties());
+            brokerList = ((String) publishConfig.get(PublishConstants.BROKER_LIST)).trim();
+            producer = KafkaProducerManager.INSTANCE.getProducer(brokerList, publishConfig);
+            topic = ((String) publishConfig.get(PublishConstants.TOPIC)).trim();
+            mode = KafkaProducerManager.INSTANCE.getKafkaWriteMode(publishConfig);
         }
     }
 
@@ -77,10 +74,10 @@ public class AlertKafkaPublisher extends AbstractPublishPlugin {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void update(String dedupIntervalMin, Map<String, String> pluginProperties) {
+    public void update(String dedupIntervalMin, Map<String, Object> pluginProperties) {
         deduplicator.setDedupIntervalMin(dedupIntervalMin);
-        String newBrokerList = pluginProperties.get(PublishConstants.BROKER_LIST).trim();
-        String newTopic = pluginProperties.get(PublishConstants.TOPIC).trim();
+        String newBrokerList = ((String) pluginProperties.get(PublishConstants.BROKER_LIST)).trim();
+        String newTopic = ((String) pluginProperties.get(PublishConstants.TOPIC)).trim();
         if (!newBrokerList.equals(this.brokerList)) {
             if (producer != null) {
                 producer.close();

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertSlackPublisher.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertSlackPublisher.java
@@ -51,10 +51,10 @@ public class AlertSlackPublisher extends AbstractPublishPlugin {
         super.init(config, publishment, conf);
 
         if (publishment.getProperties() != null) {
-            Map<String, String> slackConfig = new HashMap<>(publishment.getProperties());
-            final String token = slackConfig.get(PublishConstants.TOKEN).trim();
-            slackChannels = slackConfig.get(PublishConstants.CHANNELS).trim();
-            severitys = slackConfig.get(PublishConstants.SEVERITYS).trim();
+            Map<String, Object> slackConfig = new HashMap<>(publishment.getProperties());
+            final String token = ((String) slackConfig.get(PublishConstants.TOKEN)).trim();
+            slackChannels = ((String) slackConfig.get(PublishConstants.CHANNELS)).trim();
+            severitys = ((String) slackConfig.get(PublishConstants.SEVERITYS)).trim();
 
             if (StringUtils.isNotEmpty(token)) {
                 LOG.debug(" Creating Slack Session... ");

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/KafkaProducerManager.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/KafkaProducerManager.java
@@ -29,6 +29,7 @@ import java.util.Properties;
  * having multiple instances.
  */
 public class KafkaProducerManager {
+
     private static final Logger LOG = LoggerFactory.getLogger(KafkaProducerManager.class);
 
     private static final String STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
@@ -45,6 +46,11 @@ public class KafkaProducerManager {
 
     private static final String KEY_SERIALIZER = "key.serializer";
     private static final String KEY_SERIALIZER_UNDERSCORE = "key_serializer";
+
+    private static final String REQUEST_REQUIRED_ACKS = "request.required.acks";
+    private static final String REQUEST_REQUIRED_ACKS_UNDERSCORE = "request_required_acks";
+    // the producer gets an acknowledgement after the leader replica has received the data
+    private static final String REQUEST_REQUIRED_ACKS_DEFAULT = "1";
 
     public static final KafkaProducerManager INSTANCE = new KafkaProducerManager();
 
@@ -72,7 +78,11 @@ public class KafkaProducerManager {
         } else {
             configMap.put(VALUE_SERIALIZER, STRING_SERIALIZER);
         }
-        configMap.put("request.required.acks", "1");
+        String requestRequiredAcks = REQUEST_REQUIRED_ACKS_DEFAULT;
+        if (kafkaConfig.containsKey(REQUEST_REQUIRED_ACKS_UNDERSCORE)) {
+            requestRequiredAcks = kafkaConfig.get(REQUEST_REQUIRED_ACKS_UNDERSCORE);
+        }
+        configMap.put(REQUEST_REQUIRED_ACKS, requestRequiredAcks);
 
         // value deserializer
         if (kafkaConfig.containsKey(VALUE_DESERIALIZER_UNDERSCORE)) {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/KafkaProducerManager.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/KafkaProducerManager.java
@@ -21,6 +21,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -52,50 +54,92 @@ public class KafkaProducerManager {
     // the producer gets an acknowledgement after the leader replica has received the data
     private static final String REQUEST_REQUIRED_ACKS_DEFAULT = "1";
 
+    private static final String PRODUCER_TYPE = "producer.type";
+
+    private static final String KEY_KAFKA_PROPERTIES = "kafka_client_config";
+
+    private static final String KEY_KAFKA_PROPERTY_NAME = "name";
+    private static final String KEY_KAFKA_PROPERTY_VALUE = "value";
+
     public static final KafkaProducerManager INSTANCE = new KafkaProducerManager();
 
-    public KafkaProducer<String, Object> getProducer(String brokerList, Map<String, String> kafkaConfig) {
+    public KafkaProducer<String, Object> getProducer(String brokerList, Map<String, Object> publishConfig) {
         Properties configMap = new Properties();
         configMap.put("bootstrap.servers", brokerList);
         configMap.put("metadata.broker.list", brokerList);
 
         // key serializer
-        if (kafkaConfig.containsKey(KEY_SERIALIZER_UNDERSCORE)) {
-            configMap.put(KEY_SERIALIZER, kafkaConfig.get(KEY_SERIALIZER_UNDERSCORE));
+        if (publishConfig.containsKey(KEY_SERIALIZER_UNDERSCORE)) {
+            configMap.put(KEY_SERIALIZER, publishConfig.get(KEY_SERIALIZER_UNDERSCORE));
         } else {
             configMap.put(KEY_SERIALIZER, STRING_SERIALIZER);
         }
 
-        if (kafkaConfig.containsKey(KEY_DESERIALIZER_UNDERSCORE)) {
-            configMap.put(KEY_DESERIALIZER, kafkaConfig.get(KEY_DESERIALIZER_UNDERSCORE));
+        if (publishConfig.containsKey(KEY_DESERIALIZER_UNDERSCORE)) {
+            configMap.put(KEY_DESERIALIZER, publishConfig.get(KEY_DESERIALIZER_UNDERSCORE));
         } else {
             configMap.put(KEY_DESERIALIZER, STRING_DESERIALIZER);
         }
 
         // value serializer
-        if (kafkaConfig.containsKey(VALUE_SERIALIZER_UNDERSCORE)) {
-            configMap.put(VALUE_SERIALIZER, kafkaConfig.get(VALUE_SERIALIZER_UNDERSCORE));
+        if (publishConfig.containsKey(VALUE_SERIALIZER_UNDERSCORE)) {
+            configMap.put(VALUE_SERIALIZER, publishConfig.get(VALUE_SERIALIZER_UNDERSCORE));
         } else {
             configMap.put(VALUE_SERIALIZER, STRING_SERIALIZER);
         }
         String requestRequiredAcks = REQUEST_REQUIRED_ACKS_DEFAULT;
-        if (kafkaConfig.containsKey(REQUEST_REQUIRED_ACKS_UNDERSCORE)) {
-            requestRequiredAcks = kafkaConfig.get(REQUEST_REQUIRED_ACKS_UNDERSCORE);
+        if (publishConfig.containsKey(REQUEST_REQUIRED_ACKS_UNDERSCORE)) {
+            requestRequiredAcks = (String) publishConfig.get(REQUEST_REQUIRED_ACKS_UNDERSCORE);
         }
         configMap.put(REQUEST_REQUIRED_ACKS, requestRequiredAcks);
 
         // value deserializer
-        if (kafkaConfig.containsKey(VALUE_DESERIALIZER_UNDERSCORE)) {
-            configMap.put(VALUE_DESERIALIZER, kafkaConfig.get(VALUE_DESERIALIZER_UNDERSCORE));
+        if (publishConfig.containsKey(VALUE_DESERIALIZER_UNDERSCORE)) {
+            configMap.put(VALUE_DESERIALIZER, publishConfig.get(VALUE_DESERIALIZER_UNDERSCORE));
         } else {
             configMap.put(VALUE_DESERIALIZER, STRING_DESERIALIZER);
         }
+        // kafka config will overwrite the config defined in publishment properties
+        if (publishConfig.containsKey(KEY_KAFKA_PROPERTIES)) {
+            Map<String, Object> kafkaProperties = getKafkaProperties(publishConfig.get(KEY_KAFKA_PROPERTIES));
+            kafkaProperties.forEach((k, v) -> configMap.put(k, v));
+        }
 
         if (LOG.isInfoEnabled()) {
-            LOG.info(" given kafka config {}, create producer config map {}", kafkaConfig, configMap);
+            LOG.info(" given kafka config {}, create producer config map {}", publishConfig, configMap);
         }
 
         KafkaProducer<String, Object> producer = new KafkaProducer<>(configMap);
         return producer;
     }
+
+    public KafkaWriteMode getKafkaWriteMode(Map<String, Object> publishConfig) {
+        if (publishConfig.containsKey(KEY_KAFKA_PROPERTIES)) {
+            return KafkaWriteMode.fromString((String) getKafkaProperty(publishConfig.get(KEY_KAFKA_PROPERTIES), PRODUCER_TYPE));
+        }
+        return KafkaWriteMode.async;
+    }
+
+    private Map<String, Object> getKafkaProperties(Object kafkaProperties) {
+        Map<String, Object> result = new HashMap<String, Object>();
+        try {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> tempKafkaProperties = (List<Map<String, Object>>) kafkaProperties;
+            if (tempKafkaProperties != null) {
+                tempKafkaProperties.forEach(one -> {
+                    if (one.containsKey(KEY_KAFKA_PROPERTY_NAME) && one.containsKey(KEY_KAFKA_PROPERTY_VALUE)) {
+                        result.put((String) one.get(KEY_KAFKA_PROPERTY_NAME), one.get(KEY_KAFKA_PROPERTY_VALUE));
+                    }
+                });
+            }
+        } catch (ClassCastException e) {
+            LOG.warn("fail to cast kafka properties", e);
+        }
+        return result;
+    }
+
+    private Object getKafkaProperty(Object kafkaProperties, String propertyName) {
+        return getKafkaProperties(kafkaProperties).get(propertyName);
+    }
+
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/KafkaWriteMode.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/KafkaWriteMode.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.alert.engine.publisher.impl;
+
+public enum KafkaWriteMode {
+
+    sync, async;
+
+    public static KafkaWriteMode fromString(String mode) {
+        for (KafkaWriteMode one : KafkaWriteMode.values()) {
+            if (one.name().equalsIgnoreCase(mode)) {
+                return one;
+            }
+        }
+        // default mode is async
+        return async;
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/AlertKafkaPublisherTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/publisher/AlertKafkaPublisherTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.alert.engine.publisher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.coordinator.Publishment;
+import org.apache.eagle.alert.engine.coordinator.StreamColumn;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+import org.apache.eagle.alert.engine.publisher.dedup.DedupCache;
+import org.apache.eagle.alert.engine.publisher.impl.AlertKafkaPublisher;
+import org.apache.eagle.alert.utils.KafkaEmbedded;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import kafka.consumer.Consumer;
+import kafka.consumer.ConsumerConfig;
+import kafka.consumer.KafkaStream;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.MessageAndMetadata;
+
+public class AlertKafkaPublisherTest {
+
+    private static final String TEST_TOPIC_NAME = "test";
+
+    private static KafkaEmbedded kafka;
+    private static Config config;
+
+    private static List<String> outputMessages = new ArrayList<String>();
+
+    @BeforeClass
+    public static void setup() {
+        kafka = new KafkaEmbedded(9092, 2181);
+
+        System.setProperty("config.resource", "/simple/application-integration.conf");
+        config = ConfigFactory.load();
+
+        consumeWithOutput(outputMessages);
+    }
+
+    @AfterClass
+    public static void end() {
+        if (kafka != null) {
+            kafka.shutdown();
+        }
+    }
+
+    @Test
+    public void testAsync() throws Exception {
+        StreamDefinition stream = createStream();
+        PolicyDefinition policy = createPolicy(stream.getStreamId(), "testPolicy");
+
+        AlertKafkaPublisher publisher = new AlertKafkaPublisher();
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put(PublishConstants.BROKER_LIST, "localhost:9092");
+        properties.put(PublishConstants.TOPIC, TEST_TOPIC_NAME);
+        properties.put(PublishConstants.WRITE_MODE, "async");
+
+        Publishment publishment = new Publishment();
+        publishment.setName("testAsyncPublishment");
+        publishment.setType("org.apache.eagle.alert.engine.publisher.impl.AlertKafkaPublisher");
+        publishment.setPolicyIds(Arrays.asList(policy.getName()));
+        publishment.setDedupIntervalMin("PT0M");
+        publishment.setProperties(properties);
+        publishment.setSerializer("org.apache.eagle.alert.engine.publisher.impl.JsonEventSerializer");
+        publishment.setProperties(properties);
+        Map<String, String> conf = new HashMap<String, String>();
+        publisher.init(config, publishment, conf);
+
+        AlertStreamEvent event = createEvent(stream, policy,
+            new Object[] {System.currentTimeMillis(), "host1", "testPolicy-host1-01", "open", 0, 0});
+
+        outputMessages.clear();
+
+        publisher.onAlert(event);
+        Thread.sleep(3000);
+
+        Assert.assertEquals(1, outputMessages.size());
+
+        publisher.close();
+    }
+
+    @Test
+    public void testSync() throws Exception {
+        StreamDefinition stream = createStream();
+        PolicyDefinition policy = createPolicy(stream.getStreamId(), "testPolicy");
+
+        AlertKafkaPublisher publisher = new AlertKafkaPublisher();
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put(PublishConstants.BROKER_LIST, "localhost:9092");
+        properties.put(PublishConstants.TOPIC, TEST_TOPIC_NAME);
+        properties.put(PublishConstants.WRITE_MODE, "sync");
+
+        Publishment publishment = new Publishment();
+        publishment.setName("testAsyncPublishment");
+        publishment.setType("org.apache.eagle.alert.engine.publisher.impl.AlertKafkaPublisher");
+        publishment.setPolicyIds(Arrays.asList(policy.getName()));
+        publishment.setDedupIntervalMin("PT0M");
+        publishment.setProperties(properties);
+        publishment.setSerializer("org.apache.eagle.alert.engine.publisher.impl.JsonEventSerializer");
+        publishment.setProperties(properties);
+        Map<String, String> conf = new HashMap<String, String>();
+        publisher.init(config, publishment, conf);
+
+        AlertStreamEvent event = createEvent(stream, policy,
+            new Object[] {System.currentTimeMillis(), "host1", "testPolicy-host1-01", "open", 0, 0});
+
+        outputMessages.clear();
+
+        publisher.onAlert(event);
+        Thread.sleep(3000);
+
+        Assert.assertEquals(1, outputMessages.size());
+
+        publisher.close();
+    }
+
+    private static void consumeWithOutput(final List<String> outputMessages) {
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Properties props = new Properties();
+                props.put("group.id", "B");
+                props.put("zookeeper.connect", "127.0.0.1:2181");
+                props.put("zookeeper.session.timeout.ms", "4000");
+                props.put("zookeeper.sync.time.ms", "2000");
+                props.put("auto.commit.interval.ms", "1000");
+                props.put("auto.offset.reset", "smallest");
+
+                ConsumerConnector jcc = null;
+                try {
+                    ConsumerConfig ccfg = new ConsumerConfig(props);
+                    jcc = Consumer.createJavaConsumerConnector(ccfg);
+                    Map<String, Integer> topicCountMap = new HashMap<String, Integer>();
+                    topicCountMap.put(TEST_TOPIC_NAME, 1);
+                    Map<String, List<KafkaStream<byte[], byte[]>>> topicMap = jcc.createMessageStreams(topicCountMap);
+                    KafkaStream<byte[], byte[]> cstrm = topicMap.get(TEST_TOPIC_NAME).get(0);
+                    for (MessageAndMetadata<byte[], byte[]> mm : cstrm) {
+                        String message = new String(mm.message());
+                        outputMessages.add(message);
+                        System.err.println(message);
+
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException e) {
+                        }
+                    }
+                } finally {
+                    if (jcc != null) {
+                        jcc.shutdown();
+                    }
+                }
+            }
+        });
+        t.start();
+    }
+
+    private AlertStreamEvent createEvent(StreamDefinition stream, PolicyDefinition policy, Object[] data) {
+        AlertStreamEvent event = new AlertStreamEvent();
+        event.setPolicyId(policy.getName());
+        event.setSchema(stream);
+        event.setStreamId(stream.getStreamId());
+        event.setTimestamp(System.currentTimeMillis());
+        event.setCreatedTime(System.currentTimeMillis());
+        event.setData(data);
+        return event;
+    }
+
+    private StreamDefinition createStream() {
+        StreamDefinition sd = new StreamDefinition();
+        StreamColumn tsColumn = new StreamColumn();
+        tsColumn.setName("timestamp");
+        tsColumn.setType(StreamColumn.Type.LONG);
+
+        StreamColumn hostColumn = new StreamColumn();
+        hostColumn.setName("host");
+        hostColumn.setType(StreamColumn.Type.STRING);
+
+        StreamColumn alertKeyColumn = new StreamColumn();
+        alertKeyColumn.setName("alertKey");
+        alertKeyColumn.setType(StreamColumn.Type.STRING);
+
+        StreamColumn stateColumn = new StreamColumn();
+        stateColumn.setName("state");
+        stateColumn.setType(StreamColumn.Type.STRING);
+
+        // dedupCount, dedupFirstOccurrence
+
+        StreamColumn dedupCountColumn = new StreamColumn();
+        dedupCountColumn.setName("dedupCount");
+        dedupCountColumn.setType(StreamColumn.Type.LONG);
+
+        StreamColumn dedupFirstOccurrenceColumn = new StreamColumn();
+        dedupFirstOccurrenceColumn.setName(DedupCache.DEDUP_FIRST_OCCURRENCE);
+        dedupFirstOccurrenceColumn.setType(StreamColumn.Type.LONG);
+
+        sd.setColumns(Arrays.asList(tsColumn, hostColumn, alertKeyColumn, stateColumn, dedupCountColumn,
+            dedupFirstOccurrenceColumn));
+        sd.setDataSource("testDatasource");
+        sd.setStreamId("testStream");
+        sd.setDescription("test stream");
+        return sd;
+    }
+
+    private PolicyDefinition createPolicy(String streamName, String policyName) {
+        PolicyDefinition pd = new PolicyDefinition();
+        PolicyDefinition.Definition def = new PolicyDefinition.Definition();
+        // expression, something like "PT5S,dynamic,1,host"
+        def.setValue("test");
+        def.setType("siddhi");
+        pd.setDefinition(def);
+        pd.setInputStreams(Arrays.asList("inputStream"));
+        pd.setOutputStreams(Arrays.asList("outputStream"));
+        pd.setName(policyName);
+        pd.setDescription(String.format("Test policy for stream %s", streamName));
+
+        StreamPartition sp = new StreamPartition();
+        sp.setStreamId(streamName);
+        sp.setColumns(Arrays.asList("host"));
+        sp.setType(StreamPartition.Type.GROUPBY);
+        pd.addPartition(sp);
+        return pd;
+    }
+
+}


### PR DESCRIPTION
Kafka send alert in sync would limit the throughput. Make this configurable, and use async by default