### PR TITLE
EAGLE-680 Can't genetate Html coverage report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1150,7 +1150,6 @@
                     <artifactId>cobertura-maven-plugin</artifactId>
                     <version>${cobertura-maven.version}</version>
                     <configuration>
-                        <format>xml</format>
                         <maxmem>256m</maxmem>
                         <!-- aggregated reports for multi-module projects -->
                         <aggregate>true</aggregate>


### PR DESCRIPTION
EAGLE-680 Can't genetate Html coverage report
- remove xml format in eagle-parent pom.xml
