### PR TITLE
[EAGLE-348] Alert engine base on spark streaming

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-assembly/pom.xml
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-assembly/pom.xml
@@ -53,7 +53,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>alert-spark</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- package test cases -->
         <dependency>
             <groupId>org.apache.eagle</groupId>

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/AlertBoltSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/AlertBoltSpec.java
@@ -18,7 +18,8 @@ package org.apache.eagle.alert.coordination.model;
 
 import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,12 +30,11 @@ import java.util.Map;
  *
  * @since Apr 29, 2016
  */
-public class AlertBoltSpec {
+public class AlertBoltSpec implements Serializable {
     private String version;
     private String topologyName;
 
     // mapping from boltId to list of PolicyDefinitions
-    @JsonIgnore
     private Map<String, List<PolicyDefinition>> boltPoliciesMap = new HashMap<String, List<PolicyDefinition>>();
 
     // mapping from boltId to list of PolicyDefinition's Ids
@@ -87,12 +87,10 @@ public class AlertBoltSpec {
         }
     }
 
-    @JsonIgnore
     public Map<String, List<PolicyDefinition>> getBoltPoliciesMap() {
         return boltPoliciesMap;
     }
 
-    @JsonIgnore
     public void setBoltPoliciesMap(Map<String, List<PolicyDefinition>> boltPoliciesMap) {
         this.boltPoliciesMap = boltPoliciesMap;
     }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/Kafka2TupleMetadata.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/Kafka2TupleMetadata.java
@@ -18,13 +18,15 @@ package org.apache.eagle.alert.coordination.model;
 
 import com.google.common.base.Objects;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serializable;
 import java.util.Map;
 
 /**
  * This metadata model controls how to convert kafka topic into tuple stream.
  * @since Apr 5, 2016
  */
-public class Kafka2TupleMetadata {
+public class Kafka2TupleMetadata  implements Serializable {
     private String type;
     private String name; // data source name
     private Map<String, String> properties;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/PolicyWorkerQueue.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/PolicyWorkerQueue.java
@@ -20,11 +20,13 @@ import org.apache.eagle.alert.engine.coordinator.StreamPartition;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class PolicyWorkerQueue {
+public class PolicyWorkerQueue implements Serializable {
 
     private StreamPartition partition;
     private List<WorkSlot> workers;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/PublishSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/PublishSpec.java
@@ -17,10 +17,12 @@
 package org.apache.eagle.alert.coordination.model;
 
 import org.apache.eagle.alert.engine.coordinator.Publishment;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PublishSpec {
+public class PublishSpec implements Serializable {
 
     private String topologyName;
     // actually only publish spec for one topology

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/RouterSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/RouterSpec.java
@@ -18,11 +18,12 @@ package org.apache.eagle.alert.coordination.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 
-public class RouterSpec {
+public class RouterSpec implements Serializable {
     private String version;
     private String topologyName;
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/SpoutSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/SpoutSpec.java
@@ -18,6 +18,7 @@ package org.apache.eagle.alert.coordination.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ import java.util.Optional;
  *
  * @since Apr 18, 2016
  */
-public class SpoutSpec {
+public class SpoutSpec implements Serializable {
     private String version;
 
     //    private String spoutId;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/StreamRepartitionMetadata.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/StreamRepartitionMetadata.java
@@ -18,6 +18,7 @@ package org.apache.eagle.alert.coordination.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ import java.util.List;
  * This meta-data controls how tuple streamId is repartitioned.
  * @since Apr 25, 2016
  */
-public class StreamRepartitionMetadata {
+public class StreamRepartitionMetadata  implements Serializable {
     private String topicName;
     private String streamId;
     /**

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/StreamRepartitionStrategy.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/StreamRepartitionStrategy.java
@@ -19,10 +19,12 @@ package org.apache.eagle.alert.coordination.model;
 import org.apache.eagle.alert.engine.coordinator.StreamPartition;
 
 import org.apache.commons.collections.CollectionUtils;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class StreamRepartitionStrategy {
+public class StreamRepartitionStrategy implements Serializable {
     public StreamPartition partition;
 
     public int numTotalParticipatingRouterBolts = 0;      // how many group-by bolts participate policy evaluation
@@ -44,7 +46,7 @@ public class StreamRepartitionStrategy {
         }
         StreamRepartitionStrategy o = (StreamRepartitionStrategy) obj;
         return partition.equals(o.partition)
-            && CollectionUtils.isEqualCollection(totalTargetBoltIds, o.totalTargetBoltIds);
+                && CollectionUtils.isEqualCollection(totalTargetBoltIds, o.totalTargetBoltIds);
     }
 
     public StreamPartition getPartition() {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/StreamRouterSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/StreamRouterSpec.java
@@ -19,6 +19,8 @@ package org.apache.eagle.alert.coordination.model;
 import org.apache.eagle.alert.engine.coordinator.StreamPartition;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -29,7 +31,7 @@ import java.util.Objects;
  *
  * <p>Key is StreamPartition.
  */
-public class StreamRouterSpec {
+public class StreamRouterSpec implements Serializable {
     private String streamId;
     private StreamPartition partition; // The meta-data to build
     // StreamPartitioner

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/Tuple2StreamMetadata.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/Tuple2StreamMetadata.java
@@ -16,6 +16,7 @@
  */
 package org.apache.eagle.alert.coordination.model;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -34,7 +35,7 @@ import java.util.Set;
  *
  * @since 4/25/16
  */
-public class Tuple2StreamMetadata {
+public class Tuple2StreamMetadata implements Serializable {
     /**
      * only messages belonging to activeStreamNames will be kept while
      * transforming tuple into stream.

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/WorkSlot.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/WorkSlot.java
@@ -19,12 +19,13 @@ package org.apache.eagle.alert.coordination.model;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * A slot is simply a bolt.
  */
-public class WorkSlot {
+public class WorkSlot implements Serializable {
     public String topologyName;
     public String boltId;
 
@@ -64,7 +65,7 @@ public class WorkSlot {
         }
         WorkSlot workSlot = (WorkSlot) other;
         return Objects.equals(topologyName, workSlot.topologyName)
-            && Objects.equals(boltId, workSlot.boltId);
+                && Objects.equals(boltId, workSlot.boltId);
     }
 
     @Override

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
@@ -19,6 +19,7 @@ package org.apache.eagle.alert.engine.coordinator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -27,7 +28,7 @@ import java.util.Objects;
  * @since Apr 11, 2016.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Publishment {
+public class Publishment implements Serializable {
 
     private String name;
     private String type;
@@ -126,11 +127,11 @@ public class Publishment {
         if (obj instanceof Publishment) {
             Publishment p = (Publishment) obj;
             return (Objects.equals(name, p.getName()) && Objects.equals(type, p.getType())
-                && Objects.equals(dedupIntervalMin, p.getDedupIntervalMin())
-                && Objects.equals(dedupFields, p.getDedupFields())
-                && Objects.equals(dedupStateField, p.getDedupStateField())
-                && Objects.equals(overrideDeduplicator, p.getOverrideDeduplicator())
-                && Objects.equals(policyIds, p.getPolicyIds()) && properties.equals(p.getProperties()));
+                    && Objects.equals(dedupIntervalMin, p.getDedupIntervalMin())
+                    && Objects.equals(dedupFields, p.getDedupFields())
+                    && Objects.equals(dedupStateField, p.getDedupStateField())
+                    && Objects.equals(overrideDeduplicator, p.getOverrideDeduplicator())
+                    && Objects.equals(policyIds, p.getPolicyIds()) && properties.equals(p.getProperties()));
         }
         return false;
     }
@@ -138,14 +139,14 @@ public class Publishment {
     @Override
     public int hashCode() {
         return new HashCodeBuilder().append(name).append(type).append(dedupIntervalMin).append(policyIds)
-            .append(properties).build();
+                .append(properties).build();
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Publishment[name:").append(name).append(",type:").append(type).append(",policyId:")
-            .append(policyIds).append(",properties:").append(properties);
+                .append(policyIds).append(",properties:").append(properties);
         return sb.toString();
     }
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/service/SpecMetadataServiceClientImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/service/SpecMetadataServiceClientImpl.java
@@ -1,0 +1,256 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.service;
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
+import com.typesafe.config.Config;
+import org.apache.eagle.alert.coordination.model.*;
+import org.apache.eagle.alert.coordination.model.internal.Topology;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.coordinator.Publishment;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamingCluster;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class SpecMetadataServiceClientImpl implements IMetadataServiceClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpecMetadataServiceClientImpl.class);
+
+    private static final String METADATA_SPOUT_PATH = "/specmetadata/spoutSpec";
+    private static final String METADATA_ROUTER_PATH = "/specmetadata/routerSpec";
+    private static final String METADATA_ALERTBOLT_PATH = "/specmetadata/alertBoltSpec";
+    private static final String METADATA_PUBLISH_PATH = "/specmetadata/publishSpec";
+    private static final String METADATA_SDS_PATH = "/specmetadata/sds";
+
+    private static final String EAGLE_CORRELATION_CONTEXT = "metadataService.context";
+    private static final String EAGLE_CORRELATION_SERVICE_PORT = "metadataService.port";
+    private static final String EAGLE_CORRELATION_SERVICE_HOST = "metadataService.host";
+
+    private String host;
+    private int port;
+    private String context;
+    private transient Client client;
+    private String basePath;
+
+    public SpecMetadataServiceClientImpl(Config config) {
+        this(config.getString(EAGLE_CORRELATION_SERVICE_HOST), config.getInt(EAGLE_CORRELATION_SERVICE_PORT), config
+                .getString(EAGLE_CORRELATION_CONTEXT));
+        basePath = buildBasePath();
+    }
+
+    public SpecMetadataServiceClientImpl(String host, int port, String context) {
+        this.host = host;
+        this.port = port;
+        this.context = context;
+        this.basePath = buildBasePath();
+        ClientConfig cc = new DefaultClientConfig();
+        cc.getProperties().put(DefaultClientConfig.PROPERTY_CONNECT_TIMEOUT, 60 * 1000);
+        cc.getProperties().put(DefaultClientConfig.PROPERTY_READ_TIMEOUT, 60 * 1000);
+        cc.getClasses().add(JacksonJsonProvider.class);
+        cc.getProperties().put(URLConnectionClientHandler.PROPERTY_HTTP_URL_CONNECTION_SET_METHOD_WORKAROUND, true);
+        this.client = Client.create(cc);
+        client.addFilter(new com.sun.jersey.api.client.filter.GZIPContentEncodingFilter());
+    }
+
+    private String buildBasePath() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("http://");
+        sb.append(host);
+        sb.append(":");
+        sb.append(port);
+        sb.append(context);
+        return sb.toString();
+    }
+
+    @Override
+    public void addStreamingCluster(StreamingCluster cluster) {
+
+    }
+
+    @Override
+    public void addStreamingClusters(List<StreamingCluster> clusters) {
+
+    }
+
+    @Override
+    public List<StreamingCluster> listClusters() {
+        return null;
+    }
+
+    @Override
+    public List<Topology> listTopologies() {
+        return null;
+    }
+
+    @Override
+    public void addTopology(Topology t) {
+
+    }
+
+    @Override
+    public void addTopologies(List<Topology> topologies) {
+
+    }
+
+    @Override
+    public void addPolicy(PolicyDefinition policy) {
+
+    }
+
+    @Override
+    public void addPolicies(List<PolicyDefinition> policies) {
+
+    }
+
+    @Override
+    public List<PolicyDefinition> listPolicies() {
+        return null;
+    }
+
+    @Override
+    public void addStreamDefinition(StreamDefinition streamDef) {
+
+    }
+
+    @Override
+    public void addStreamDefinitions(List<StreamDefinition> streamDefs) {
+
+    }
+
+    @Override
+    public List<StreamDefinition> listStreams() {
+        return null;
+    }
+
+    @Override
+    public void addDataSource(Kafka2TupleMetadata k2t) {
+
+    }
+
+    @Override
+    public void addDataSources(List<Kafka2TupleMetadata> k2ts) {
+
+    }
+
+    @Override
+    public List<Kafka2TupleMetadata> listDataSources() {
+        return null;
+    }
+
+    @Override
+    public void addPublishment(Publishment pub) {
+
+    }
+
+    @Override
+    public void addPublishments(List<Publishment> pubs) {
+
+    }
+
+    @Override
+    public List<Publishment> listPublishment() {
+        return null;
+    }
+
+    @Override
+    public List<SpoutSpec> listSpoutMetadata() {
+        return null;
+    }
+
+    @Override
+    public ScheduleState getVersionedSpec() {
+        return null;
+    }
+
+    @Override
+    public ScheduleState getVersionedSpec(String version) {
+        return null;
+    }
+
+    @Override
+    public void addScheduleState(ScheduleState state) {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    public Map<String, StreamDefinition> getSds() {
+        WebResource r = client.resource(basePath + METADATA_SDS_PATH);
+        ClientResponse resp = r.accept(MediaType.APPLICATION_JSON_TYPE).type(MediaType.APPLICATION_JSON)
+                .get(ClientResponse.class);
+        Map<String, StreamDefinition> sds = resp.getEntity(new GenericType<Map<String, StreamDefinition>>() {
+        });
+        return sds;
+    }
+
+    private <T> T listOne(String path, Class<T> tClz) {
+        LOG.info("query URL {}", basePath + path);
+        WebResource r = client.resource(basePath + path);
+
+        ClientResponse resp = r.accept(MediaType.APPLICATION_JSON_TYPE).type(MediaType.APPLICATION_JSON)
+                .get(ClientResponse.class);
+        if (resp.getStatus() < 300) {
+            try {
+                return resp.getEntity(tClz);
+            } catch (Exception e) {
+                LOG.warn(" list one entity failed, ignored and continute, path {}, message {}!", path, e.getMessage());
+            }
+        } else {
+            LOG.warn("fail querying metadata service {} with http status {}", basePath + path, resp.getStatus());
+        }
+        return null;
+    }
+
+    public SpoutSpec getSpoutSpec() {
+        return listOne(METADATA_SPOUT_PATH, SpoutSpec.class);
+    }
+
+    public RouterSpec getRouterSpec() {
+        return listOne(METADATA_ROUTER_PATH, RouterSpec.class);
+    }
+
+    public AlertBoltSpec getAlertBoltSpec() {
+        return listOne(METADATA_ALERTBOLT_PATH, AlertBoltSpec.class);
+    }
+
+    public PublishSpec getPublishSpec() {
+        return listOne(METADATA_PUBLISH_PATH, PublishSpec.class);
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/CompositePolicyHandler.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/CompositePolicyHandler.java
@@ -18,11 +18,13 @@ package org.apache.eagle.alert.engine.evaluator;
 
 import org.apache.eagle.alert.engine.Collector;
 import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.evaluator.impl.SiddhiPolicyHandler;
 import org.apache.eagle.alert.engine.model.AlertStreamEvent;
 import org.apache.eagle.alert.engine.model.StreamEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +32,7 @@ import java.util.Map;
 /**
  * Created on 7/27/16.
  */
-public class CompositePolicyHandler implements PolicyStreamHandler {
+public class CompositePolicyHandler implements PolicyStreamHandler, Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(CompositePolicyHandler.class);
 
     private PolicyStreamHandler policyHandler;
@@ -93,4 +95,17 @@ public class CompositePolicyHandler implements PolicyStreamHandler {
         }
     }
 
+    public void clearHandlers() {
+        this.handlers = new ArrayList<>();
+    }
+
+    public void restoreSiddhiSnapshot(byte[] siddhiSnapshot) {
+        SiddhiPolicyHandler siddhiPolicyHandler = (SiddhiPolicyHandler) policyHandler;
+        siddhiPolicyHandler.restoreSiddhiSnapshot(siddhiSnapshot);
+    }
+
+    public byte[] closeAndSnapShot() {
+        SiddhiPolicyHandler siddhiPolicyHandler = (SiddhiPolicyHandler) policyHandler;
+        return siddhiPolicyHandler.closeAndSnapShot();
+    }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/AlertBoltOutputCollectorSparkWrapper.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/AlertBoltOutputCollectorSparkWrapper.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.evaluator.impl;
+
+import org.apache.eagle.alert.engine.AlertStreamCollector;
+import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+public class AlertBoltOutputCollectorSparkWrapper implements AlertStreamCollector, Serializable {
+    private final LinkedList<Tuple2<String, AlertStreamEvent>> collector = new LinkedList<>();
+
+    public AlertBoltOutputCollectorSparkWrapper() {
+    }
+
+    @Override
+    public void emit(AlertStreamEvent event) {
+        collector.add(new Tuple2(event.getStreamId(), event));
+    }
+
+    public List<Tuple2<String, AlertStreamEvent>> emitResult() {
+        if (collector.isEmpty()) {
+            return Collections.emptyList();
+        }
+        LinkedList<Tuple2<String, AlertStreamEvent>> result = new LinkedList<>();
+        result.addAll(collector);
+        return result;
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/PolicyGroupEvaluatorImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/PolicyGroupEvaluatorImpl.java
@@ -56,6 +56,33 @@ public class PolicyGroupEvaluatorImpl implements PolicyGroupEvaluator {
         Thread.currentThread().setName(policyEvaluatorId);
     }
 
+    public void init(StreamContext context, AlertStreamCollector collector, Map<String, PolicyDefinition> policyDefinitionMap,
+                     Map<String, CompositePolicyHandler> policyStreamHandlerMap, byte[] siddhiSnapshot) {
+        this.collector = collector;
+        this.policyStreamHandlerMap = policyStreamHandlerMap;
+        this.policyDefinitionMap = policyDefinitionMap;
+        this.context = context;
+        this.policyStreamHandlerMap.forEach((policyName, compositePolicyHandler) -> {
+            PolicyHandlerContext policyHandlerContext = new PolicyHandlerContext();
+            policyHandlerContext.setPolicyCounter(this.context.counter());
+            PolicyDefinition policyDefinition = policyDefinitionMap.get(policyName);
+            policyHandlerContext.setPolicyDefinition(policyDefinition);
+            policyHandlerContext.setPolicyEvaluator(this);
+            policyHandlerContext.setPolicyEvaluatorId(policyEvaluatorId);
+            try {
+                compositePolicyHandler.clearHandlers();
+                compositePolicyHandler.prepare(this.collector, policyHandlerContext);
+                if (siddhiSnapshot != null) {
+                    compositePolicyHandler.restoreSiddhiSnapshot(siddhiSnapshot);
+                }
+            } catch (Exception e) {
+                LOG.error("Initialized policy handler for policy error: {}", policyDefinition);
+            }
+            LOG.info("Initialized policy handler for policy end : {}", policyDefinition);
+        });
+        Thread.currentThread().setName(policyEvaluatorId);
+    }
+
     public void nextEvent(PartitionedEvent event) {
         this.context.counter().scope("receive_count").incr();
         dispatch(event);
@@ -74,6 +101,19 @@ public class PolicyGroupEvaluatorImpl implements PolicyGroupEvaluator {
                 LOG.error("Failed to close handler {}", handler.toString(), e);
             }
         }
+    }
+
+    public byte[] closeAndSnapShot() {
+        byte[] snapshot = null;
+        for (PolicyStreamHandler handler : policyStreamHandlerMap.values()) {
+            try {
+                CompositePolicyHandler compositePolicyHandler = (CompositePolicyHandler) handler;
+                snapshot = compositePolicyHandler.closeAndSnapShot();
+            } catch (Exception e) {
+                LOG.error("Failed to closeAndSnapShot handler {}", handler.toString(), e);
+            }
+        }
+        return snapshot;
     }
 
     /**
@@ -105,8 +145,8 @@ public class PolicyGroupEvaluatorImpl implements PolicyGroupEvaluator {
 
     private static boolean isAcceptedByPolicy(PartitionedEvent event, PolicyDefinition policy) {
         return policy.getPartitionSpec().contains(event.getPartition())
-            && (policy.getInputStreams().contains(event.getEvent().getStreamId())
-            || policy.getDefinition().getInputStreams().contains(event.getEvent().getStreamId()));
+                && (policy.getInputStreams().contains(event.getEvent().getStreamId())
+                || policy.getDefinition().getInputStreams().contains(event.getEvent().getStreamId()));
     }
 
     @Override
@@ -175,6 +215,14 @@ public class PolicyGroupEvaluatorImpl implements PolicyGroupEvaluator {
 
     public CompositePolicyHandler getPolicyHandler(String policy) {
         return policyStreamHandlerMap.get(policy);
+    }
+
+    public Map<String, PolicyDefinition> getPolicyDefinitionMap() {
+        return this.policyDefinitionMap;
+    }
+
+    public Map<String, CompositePolicyHandler> getPolicyStreamHandlerMap() {
+        return this.policyStreamHandlerMap;
     }
 
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertPublisherImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertPublisherImpl.java
@@ -49,6 +49,19 @@ public class AlertPublisherImpl implements AlertPublisher {
         this.name = name;
     }
 
+    public AlertPublisherImpl(String name, List<Publishment> publishments) {
+        this.name = name;
+        for (Publishment publishment : publishments) {
+            AlertPublishPlugin plugin = AlertPublishPluginsFactory.createNotificationPlugin(publishment, config, conf);
+            if (plugin != null) {
+                publishPluginMapping.put(publishment.getName(), plugin);
+                addPublishmentPolicies(policyPublishPluginMapping, publishment.getPolicyIds(), publishment.getName());
+            } else {
+                LOG.error("Initialized alertPublisher {} failed due to invalid format", publishment);
+            }
+        }
+    }
+
     @Override
     public void init(Config config, Map conf) {
         this.config = config;
@@ -103,9 +116,9 @@ public class AlertPublisherImpl implements AlertPublisher {
     @SuppressWarnings("unchecked")
     @Override
     public synchronized void onPublishChange(List<Publishment> added,
-                                List<Publishment> removed,
-                                List<Publishment> afterModified,
-                                List<Publishment> beforeModified) {
+                                             List<Publishment> removed,
+                                             List<Publishment> afterModified,
+                                             List<Publishment> beforeModified) {
         if (added == null) {
             added = new ArrayList<>();
         }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/impl/BasicStreamRoutePartitioner.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/impl/BasicStreamRoutePartitioner.java
@@ -23,12 +23,13 @@ import org.apache.eagle.alert.engine.router.StreamRoute;
 import org.apache.eagle.alert.engine.router.StreamRoutePartitioner;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class BasicStreamRoutePartitioner implements StreamRoutePartitioner {
+public class BasicStreamRoutePartitioner implements StreamRoutePartitioner, Serializable {
     private final List<String> outputComponentIds;
     private final StreamDefinition streamDefinition;
     private final StreamPartition streamPartition;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/impl/SparkStreamRouterBoltOutputCollector.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/impl/SparkStreamRouterBoltOutputCollector.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.router.impl;
+
+import org.apache.eagle.alert.coordination.model.PolicyWorkerQueue;
+import org.apache.eagle.alert.coordination.model.StreamRouterSpec;
+import org.apache.eagle.alert.coordination.model.WorkSlot;
+import org.apache.eagle.alert.engine.PartitionedEventCollector;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.engine.model.PartitionedEvent;
+import org.apache.eagle.alert.engine.model.StreamEvent;
+import org.apache.eagle.alert.engine.router.StreamRoute;
+import org.apache.eagle.alert.engine.router.StreamRoutePartitionFactory;
+import org.apache.eagle.alert.engine.router.StreamRoutePartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.*;
+
+public class SparkStreamRouterBoltOutputCollector implements PartitionedEventCollector, Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(SparkStreamRouterBoltOutputCollector.class);
+    private final List<Tuple2<Integer, PartitionedEvent>> outputCollector;
+    private Map<StreamPartition, StreamRouterSpec> routeSpecMap;
+    private Map<StreamPartition, List<StreamRoutePartitioner>> routePartitionerMap;
+
+    public SparkStreamRouterBoltOutputCollector(Map<StreamPartition, StreamRouterSpec> routeSpecMap, Map<StreamPartition, List<StreamRoutePartitioner>> routePartitionerMap) {
+        this.outputCollector = new ArrayList<>();
+        this.routeSpecMap = routeSpecMap;
+        this.routePartitionerMap = routePartitionerMap;
+    }
+
+    public List<Tuple2<Integer, PartitionedEvent>> emitResult() {
+        return outputCollector;
+    }
+
+    public void emit(PartitionedEvent event) {
+        try {
+            StreamPartition partition = event.getPartition();
+            StreamRouterSpec routerSpec = routeSpecMap.get(partition);
+            if (routerSpec == null) {
+                if (LOG.isDebugEnabled()) {
+                    // Don't know how to route stream, if it's correct, it's better to filter useless stream in spout side
+                    LOG.debug("Drop event {} as StreamPartition {} is not pointed to any router metadata {}", event, event.getPartition(), routeSpecMap);
+                }
+                this.drop(event);
+                return;
+            }
+
+            if (routePartitionerMap.get(routerSpec.getPartition()) == null) {
+                LOG.info("Partitioner for " + routerSpec + " is null");
+                return;
+            }
+
+            StreamEvent newEvent = event.getEvent().copy();
+
+            // Get handler for the partition
+            List<StreamRoutePartitioner> queuePartitioners = routePartitionerMap.get(partition);
+
+            //  synchronized (outputLock) {
+            for (StreamRoutePartitioner queuePartitioner : queuePartitioners) {
+                List<StreamRoute> streamRoutes = queuePartitioner.partition(newEvent);
+                // it is possible that one event can be sent to multiple slots in one slotqueue if that is All grouping
+                for (StreamRoute streamRoute : streamRoutes) {
+                    int partitionIndex = getPartitionIndex(streamRoute);
+                    try {
+                        PartitionedEvent emittedEvent = new PartitionedEvent(newEvent, routerSpec.getPartition(), streamRoute.getPartitionKey());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Emitted to partition {} with message {}", partitionIndex, emittedEvent);
+                        }
+                        outputCollector.add(new Tuple2<>(partitionIndex, event));
+                    } catch (RuntimeException ex) {
+                        LOG.info("Failed to emit to partition {} with {}", partitionIndex, newEvent, ex);
+                        throw ex;
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            LOG.info(ex.getMessage(), ex);
+        }
+    }
+
+    private Integer getPartitionIndex(StreamRoute streamRoute) {
+        return Integer.valueOf(streamRoute.getTargetComponentId().replaceAll("[^\\d.]", ""));
+    }
+
+    public void onStreamRouterSpecChange(Collection<StreamRouterSpec> added,
+                                         Collection<StreamRouterSpec> removed,
+                                         Collection<StreamRouterSpec> modified,
+                                         Map<String, StreamDefinition> sds) {
+        Map<StreamPartition, StreamRouterSpec> copyRouteSpecMap = new HashMap<>(routeSpecMap);
+        Map<StreamPartition, List<StreamRoutePartitioner>> copyRoutePartitionerMap = new HashMap<>(routePartitionerMap);
+
+        // added StreamRouterSpec i.e. there is a new StreamPartition
+        for (StreamRouterSpec spec : added) {
+            if (copyRouteSpecMap.containsKey(spec.getPartition())) {
+                LOG.error("Metadata calculation error: add existing StreamRouterSpec " + spec);
+            } else {
+                inplaceAdd(copyRouteSpecMap, copyRoutePartitionerMap, spec, sds);
+            }
+        }
+
+        // removed StreamRouterSpec i.e. there is a deleted StreamPartition
+        for (StreamRouterSpec spec : removed) {
+            if (!copyRouteSpecMap.containsKey(spec.getPartition())) {
+                LOG.error("Metadata calculation error: remove non-existing StreamRouterSpec " + spec);
+            } else {
+                inplaceRemove(copyRouteSpecMap, copyRoutePartitionerMap, spec);
+            }
+        }
+
+        // modified StreamRouterSpec, i.e. there is modified StreamPartition, for example WorkSlotQueue assignment is changed
+        for (StreamRouterSpec spec : modified) {
+            if (!copyRouteSpecMap.containsKey(spec.getPartition())) {
+                LOG.error("Metadata calculation error: modify nonexisting StreamRouterSpec " + spec);
+            } else {
+                inplaceRemove(copyRouteSpecMap, copyRoutePartitionerMap, spec);
+                inplaceAdd(copyRouteSpecMap, copyRoutePartitionerMap, spec, sds);
+            }
+        }
+        // switch
+        routeSpecMap = copyRouteSpecMap;
+        routePartitionerMap = copyRoutePartitionerMap;
+    }
+
+    private void inplaceRemove(Map<StreamPartition, StreamRouterSpec> routeSpecMap,
+                               Map<StreamPartition, List<StreamRoutePartitioner>> routePartitionerMap,
+                               StreamRouterSpec toBeRemoved) {
+        routeSpecMap.remove(toBeRemoved.getPartition());
+        routePartitionerMap.remove(toBeRemoved.getPartition());
+    }
+
+    private void inplaceAdd(Map<StreamPartition, StreamRouterSpec> routeSpecMap,
+                            Map<StreamPartition, List<StreamRoutePartitioner>> routePartitionerMap,
+                            StreamRouterSpec toBeAdded, Map<String, StreamDefinition> sds) {
+        routeSpecMap.put(toBeAdded.getPartition(), toBeAdded);
+        try {
+            List<StreamRoutePartitioner> routePartitioners = calculatePartitioner(toBeAdded, sds);
+            routePartitionerMap.put(toBeAdded.getPartition(), routePartitioners);
+        } catch (Exception e) {
+            LOG.error("ignore this failure StreamRouterSpec " + toBeAdded + ", with error" + e.getMessage(), e);
+            routeSpecMap.remove(toBeAdded.getPartition());
+            routePartitionerMap.remove(toBeAdded.getPartition());
+        }
+    }
+
+    private List<StreamRoutePartitioner> calculatePartitioner(StreamRouterSpec streamRouterSpec, Map<String, StreamDefinition> sds) throws Exception {
+        List<StreamRoutePartitioner> routePartitioners = new ArrayList<>();
+        for (PolicyWorkerQueue pwq : streamRouterSpec.getTargetQueue()) {
+            List<String> bolts = new ArrayList<>();
+            for (WorkSlot work : pwq.getWorkers()) {
+                bolts.add(work.getBoltId());
+            }
+            routePartitioners.add(StreamRoutePartitionFactory.createRoutePartitioner(
+                    bolts,
+                    sds.get(streamRouterSpec.getPartition().getStreamId()),
+                    streamRouterSpec.getPartition()));
+        }
+        return routePartitioners;
+    }
+
+    @Override
+    public void drop(PartitionedEvent event) {
+    }
+
+    public void flush() {
+
+    }
+
+    public Map<StreamPartition, StreamRouterSpec> getRouteSpecMap() {
+        return this.routeSpecMap;
+    }
+
+    public Map<StreamPartition, List<StreamRoutePartitioner>> getRoutePartitionerMap() {
+        return this.routePartitionerMap;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/impl/StreamRouterImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/impl/StreamRouterImpl.java
@@ -23,6 +23,8 @@ import org.apache.eagle.alert.engine.coordinator.StreamSortSpec;
 import org.apache.eagle.alert.engine.model.PartitionedEvent;
 import org.apache.eagle.alert.engine.router.StreamRouter;
 import org.apache.eagle.alert.engine.router.StreamSortHandler;
+import org.apache.eagle.alert.engine.sorter.StreamTimeClock;
+import org.apache.eagle.alert.engine.sorter.StreamTimeClockListener;
 import org.apache.eagle.alert.engine.sorter.StreamTimeClockManager;
 import org.apache.eagle.alert.engine.sorter.impl.StreamSortWindowHandlerImpl;
 import org.apache.eagle.alert.engine.sorter.impl.StreamTimeClockManagerImpl;
@@ -63,6 +65,19 @@ public class StreamRouterImpl implements StreamRouter {
         this.streamTimeClockManager = new StreamTimeClockManagerImpl();
         this.streamSortHandlers = new HashMap<>();
         this.outputCollector = outputCollector;
+        this.context = context;
+    }
+
+    public void prepare(StreamContext context, PartitionedEventCollector outputCollector, Map<StreamTimeClockListener, String> listenerStreamIdMap,
+                        Map<String, StreamTimeClock> streamIdTimeClockMap, Map<StreamPartition, StreamSortHandler> streamSortHandlerMap) {
+
+        this.streamSortHandlers = streamSortHandlerMap;
+        this.outputCollector = outputCollector;
+        listenerStreamIdMap.forEach((k, v) -> {
+            StreamSortWindowHandlerImpl streamwindow = (StreamSortWindowHandlerImpl) k;
+            streamwindow.updateOutputCollector(this.outputCollector);
+        });
+        this.streamTimeClockManager = new StreamTimeClockManagerImpl(listenerStreamIdMap, streamIdTimeClockMap);
         this.context = context;
     }
 
@@ -161,5 +176,21 @@ public class StreamRouterImpl implements StreamRouter {
             // atomic switch
             this.streamSortHandlers = copy;
         }
+    }
+
+    public Map<String, StreamTimeClock> getStreamTimeClock() {
+        return streamTimeClockManager.getAllStreamTimeClock();
+    }
+
+    public Map<StreamTimeClockListener, String> getAllListenerStreamIdMap() {
+        return streamTimeClockManager.getAllListenerStreamIdMap();
+    }
+
+    public Map<StreamPartition, StreamSortHandler> getAllStreamSortHandlerMap() {
+        return this.streamSortHandlers;
+    }
+
+    public void closeClock() {
+        streamTimeClockManager.close();
     }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/StreamTimeClock.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/StreamTimeClock.java
@@ -16,11 +16,13 @@
  */
 package org.apache.eagle.alert.engine.sorter;
 
+import java.io.Serializable;
+
 /**
  * The time clock per stream should be thread-safe between getTime and moveForward.
  * By default, we currently simple support event timestamp now.
  */
-public interface StreamTimeClock {
+public interface StreamTimeClock extends Serializable {
     /**
      * Get stream id.
      *

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/StreamTimeClockManager.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/StreamTimeClockManager.java
@@ -17,6 +17,7 @@
 package org.apache.eagle.alert.engine.sorter;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * By default, we could keep the current time clock in memory,
@@ -37,4 +38,8 @@ public interface StreamTimeClockManager extends StreamTimeClockTrigger, Serializ
     StreamTimeClock getStreamTimeClock(String streamId);
 
     void removeStreamTimeClock(String streamId);
+
+    Map<String, StreamTimeClock> getAllStreamTimeClock();
+
+    Map<StreamTimeClockListener, String> getAllListenerStreamIdMap();
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/PartitionedEventTimeOrderingComparator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/PartitionedEventTimeOrderingComparator.java
@@ -18,13 +18,14 @@ package org.apache.eagle.alert.engine.sorter.impl;
 
 import org.apache.eagle.alert.engine.model.PartitionedEvent;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 
 /**
  * TODO: Stable sorting algorithm for better performance to avoid event resorting with same timestamp?.
  */
-public class PartitionedEventTimeOrderingComparator implements Comparator<PartitionedEvent> {
+public class PartitionedEventTimeOrderingComparator implements Comparator<PartitionedEvent>, Serializable {
     public static final PartitionedEventTimeOrderingComparator INSTANCE = new PartitionedEventTimeOrderingComparator();
 
     @Override

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/StreamSortWindowHandlerImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/StreamSortWindowHandlerImpl.java
@@ -29,20 +29,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.Serializable;
 
-public class StreamSortWindowHandlerImpl implements StreamSortHandler {
+public class StreamSortWindowHandlerImpl implements StreamSortHandler, Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(StreamSortWindowHandlerImpl.class);
     private StreamWindowManager windowManager;
     private StreamSortSpec streamSortSpecSpec;
-    private PartitionedEventCollector outputCollector;
+    private transient PartitionedEventCollector outputCollector;
     private String streamId;
 
     public void prepare(String streamId, StreamSortSpec streamSortSpecSpec, PartitionedEventCollector outputCollector) {
         this.windowManager = new StreamWindowManagerImpl(
-            Period.parse(streamSortSpecSpec.getWindowPeriod()),
-            streamSortSpecSpec.getWindowMargin(),
-            PartitionedEventTimeOrderingComparator.INSTANCE,
-            outputCollector);
+                Period.parse(streamSortSpecSpec.getWindowPeriod()),
+                streamSortSpecSpec.getWindowMargin(),
+                PartitionedEventTimeOrderingComparator.INSTANCE,
+                outputCollector);
         this.streamSortSpecSpec = streamSortSpecSpec;
         this.streamId = streamId;
         this.outputCollector = outputCollector;
@@ -108,6 +109,14 @@ public class StreamSortWindowHandlerImpl implements StreamSortHandler {
             throw new NullPointerException("streamSortSpec is null");
         } else {
             return streamSortSpecSpec.hashCode();
+        }
+    }
+
+    public void updateOutputCollector(PartitionedEventCollector outputCollector) {
+        this.outputCollector = outputCollector;
+        if (this.windowManager != null) {
+            StreamWindowManagerImpl windowImpl = (StreamWindowManagerImpl) this.windowManager;
+            windowImpl.updateOutputCollector(outputCollector);
         }
     }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/StreamTimeClockManagerImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/StreamTimeClockManagerImpl.java
@@ -39,8 +39,13 @@ public final class StreamTimeClockManagerImpl implements StreamTimeClockManager 
     private static final AtomicInteger num = new AtomicInteger();
 
     public StreamTimeClockManagerImpl() {
-        listenerStreamIdMap = new HashMap<>();
-        streamIdTimeClockMap = new HashMap<>();
+        this(new HashMap<>(), new HashMap<>());
+    }
+
+    public StreamTimeClockManagerImpl(Map<StreamTimeClockListener, String> listenerStreamIdMap, Map<String, StreamTimeClock> streamIdTimeClockMap) {
+
+        this.listenerStreamIdMap = listenerStreamIdMap;
+        this.streamIdTimeClockMap = streamIdTimeClockMap;
         timer = new Timer("StreamScheduler-" + num.getAndIncrement());
         timer.schedule(new TimerTask() {
             @Override
@@ -94,6 +99,16 @@ public final class StreamTimeClockManagerImpl implements StreamTimeClockManager 
                 LOG.warn("No TimeClock found for stream {}, nothing to remove", streamId);
             }
         }
+    }
+
+    @Override
+    public Map<String, StreamTimeClock> getAllStreamTimeClock() {
+        return this.streamIdTimeClockMap;
+    }
+
+    @Override
+    public Map<StreamTimeClockListener, String> getAllListenerStreamIdMap() {
+        return this.listenerStreamIdMap;
     }
 
     @Override

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/StreamWindowManagerImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/sorter/impl/StreamWindowManagerImpl.java
@@ -30,12 +30,13 @@ import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.*;
 
-public class StreamWindowManagerImpl implements StreamWindowManager {
+public class StreamWindowManagerImpl implements StreamWindowManager, Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(StreamWindowManagerImpl.class);
     private final TreeMap<Long, StreamWindow> windowBuckets;
-    private final PartitionedEventCollector collector;
+    private transient PartitionedEventCollector collector;
     private final Period windowPeriod;
     private final long windowMargin;
     @SuppressWarnings("unused")
@@ -62,8 +63,8 @@ public class StreamWindowManagerImpl implements StreamWindowManager {
                 return window;
             } else {
                 throw new IllegalStateException("Failed to create new window, as "
-                    + DateTimeUtil.millisecondsToHumanDateWithMilliseconds(initialTime) + " is too late, only allow timestamp after "
-                    + DateTimeUtil.millisecondsToHumanDateWithMilliseconds(rejectTime));
+                        + DateTimeUtil.millisecondsToHumanDateWithMilliseconds(initialTime) + " is too late, only allow timestamp after "
+                        + DateTimeUtil.millisecondsToHumanDateWithMilliseconds(rejectTime));
             }
         }
     }
@@ -171,6 +172,13 @@ public class StreamWindowManagerImpl implements StreamWindowManager {
             windowBuckets.clear();
             stopWatch.stop();
             LOG.info("Closed {} windows in {} ms", count, stopWatch.getTime());
+        }
+    }
+
+    public void updateOutputCollector(PartitionedEventCollector outputCollector) {
+        this.collector = outputCollector;
+        if (windowBuckets != null && !windowBuckets.isEmpty()) {
+            windowBuckets.forEach((windowStartTime, streamWindow) -> streamWindow.register(outputCollector));
         }
     }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/java/org/apache/eagle/service/metadata/resource/SpecMetadataResource.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/java/org/apache/eagle/service/metadata/resource/SpecMetadataResource.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.service.metadata.resource;
+
+import org.apache.eagle.alert.coordination.model.AlertBoltSpec;
+import org.apache.eagle.alert.coordination.model.PublishSpec;
+import org.apache.eagle.alert.coordination.model.RouterSpec;
+import org.apache.eagle.alert.coordination.model.SpoutSpec;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.utils.MetadataSerDeser;
+import org.codehaus.jackson.type.TypeReference;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.Map;
+
+@Path("/specmetadata")
+@Produces("application/json")
+@Consumes("application/json")
+public class SpecMetadataResource {
+
+    public static final String SPARK = "/spark";
+
+    @Path("/spoutSpec")
+    @GET
+    public SpoutSpec getSpoutSpec() {
+        return MetadataSerDeser.deserialize(getClass().getResourceAsStream(SPARK + "/spoutSpec.json"), SpoutSpec.class);
+    }
+
+    @Path("/routerSpec")
+    @GET
+    public RouterSpec getRouterSpec() {
+        return MetadataSerDeser.deserialize(getClass().getResourceAsStream(SPARK + "/streamRouterBoltSpec.json"), RouterSpec.class);
+    }
+
+    @Path("/alertBoltSpec")
+    @GET
+    public AlertBoltSpec getAlertBoltSpec() {
+        return MetadataSerDeser.deserialize(getClass().getResourceAsStream(SPARK + "/alertBoltSpec.json"), AlertBoltSpec.class);
+    }
+
+    @Path("/publishSpec")
+    @GET
+    public PublishSpec getPublishSpec() {
+        return MetadataSerDeser.deserialize(getClass().getResourceAsStream(SPARK + "/publishSpec.json"), PublishSpec.class);
+    }
+
+    @Path("/sds")
+    @GET
+    public Map<String, StreamDefinition> getSds() {
+        return MetadataSerDeser.deserialize(getClass().getResourceAsStream(SPARK + "/streamDefinitionsSpec.json"),
+                new TypeReference<Map<String, StreamDefinition>>() {
+                });
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/alertBoltSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/alertBoltSpec.json
@@ -1,0 +1,66 @@
+{
+  "version": "version1",
+  "topologyName": "testTopology",
+  "boltPoliciesMap": {
+    "alertBolt0": [
+     {
+        "name": "policy4",
+        "description": "alertBolt0policy4",
+        "inputStreams": [
+          "oozieStream"
+        ],
+        "outputStreams": [
+          "testAlertStream"
+        ],
+        "definition": {
+          "type": "siddhi",
+          "value": " from oozieStream#window.externalTimeBatch(timestamp, 4 sec)  select ip, jobId , operation, count(1) as visitCount insert into testAlertStream;  "
+        },
+        "partitionSpec": [
+          {
+            "streamId": "oozieStream",
+            "type": "GROUPBY",
+            "columns": [
+              "operation"
+            ],
+            "sortSpec": {
+              "windowPeriod": "PT4S",
+              "windowMargin": 1000
+            }
+          }
+        ],
+        "parallelismHint": 0
+      }
+    ],
+    "alertBolt1": [
+      {
+        "name": "policy4",
+        "description": "alertBolt1policy4",
+        "inputStreams": [
+          "oozieStream"
+        ],
+        "outputStreams": [
+          "testAlertStream"
+        ],
+        "definition": {
+          "type": "siddhi",
+          "value": " from oozieStream#window.externalTimeBatch(timestamp, 2 sec)  select ip, jobId , operation, count(1) as visitCount insert into testAlertStream;  "
+        },
+        "partitionSpec": [
+          {
+            "streamId": "oozieStream",
+            "type": "GROUPBY",
+            "columns": [
+              "operation"
+            ],
+            "sortSpec": {
+              "windowPeriod": "PT4S",
+              "windowMargin": 1000
+            }
+          }
+        ],
+        "parallelismHint": 0
+      }
+    ]
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/publishSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/publishSpec.json
@@ -1,0 +1,23 @@
+{
+  "version": "version1",
+  "topologyName": "testTopology",
+  "boltId": "alertPublishBolt",
+  "publishments": [
+    {
+      "type": "org.apache.eagle.alert.engine.publisher.impl.AlertEmailPublisher",
+      "name":"email-testAlertStream",
+      "policyIds": ["policy4"],
+      "dedupIntervalMin": "PT1M",
+      "properties":{
+        "subject":"UMP Test Alert",
+        "template":"",
+	  "sender": "sender@corp.com",
+	  "recipients": "receiver@corp.com",
+	  "smtp.server":"mailhost.com",
+        "connection": "plaintext",
+        "smtp.port": "25"
+      },
+      "serializer" : "org.apache.eagle.alert.engine.publisher.impl.StringEventSerializer"
+    }
+  ]
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/spoutSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/spoutSpec.json
@@ -1,0 +1,53 @@
+{
+  "version": null,
+  "topologyId": "testTopology",
+  "kafka2TupleMetadataMap": {
+      "oozie": {
+      "type": null,
+      "name": "oozie",
+      "properties": null,
+      "topic": "oozie",
+      "schemeCls": "org.apache.eagle.alert.engine.scheme.JsonScheme",
+      "codec": null
+    }
+  },
+  "tuple2StreamMetadataMap": {
+    "oozie": {
+      "activeStreamNames": [
+        "oozieStream"
+      ],
+      "streamNameSelectorProp": {
+        "userProvidedStreamName": "oozieStream"
+      },
+      "streamNameSelectorCls": "org.apache.eagle.alert.engine.scheme.PlainStringStreamNameSelector",
+      "timestampColumn": "timestamp",
+      "timestampFormat": null
+    }
+  },
+  "streamRepartitionMetadataMap": {
+    "oozie": [
+      {
+        "topicName": "oozie",
+        "streamId": "defaultStringStream",
+        "groupingStrategies": [
+          {
+            "partition": {
+              "streamId": "oozieStream",
+              "type": "GROUPBY",
+              "columns": [
+                "operation"
+              ],
+              "sortSpec": {
+                "windowPeriod": "PT4S",
+                "windowMargin": 1000
+              }
+            },
+            "numTotalParticipatingRouterBolts": 4,
+            "startSequence": 0,
+            "totalTargetBoltIds": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/streamDefinitionsSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/streamDefinitionsSpec.json
@@ -1,0 +1,35 @@
+{
+  "oozieStream": {
+    "streamId": "oozieStream",
+    "dataSource": null,
+    "description": null,
+    "validate": false,
+    "timeseries": false,
+    "columns": [
+      {
+        "name": "ip",
+        "type": "STRING",
+        "defaultValue": null,
+        "required": false
+      },
+      {
+        "name": "jobId",
+        "type": "STRING",
+        "defaultValue": null,
+        "required": false
+      },
+      {
+        "name": "operation",
+        "type": "STRING",
+        "defaultValue": null,
+        "required": false
+      },
+      {
+        "name": "timestamp",
+        "type" : "LONG",
+        "defaultValue": 0,
+        "required":true
+      }
+    ]
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/streamRouterBoltSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata-service/src/main/resources/spark/streamRouterBoltSpec.json
@@ -1,0 +1,45 @@
+{
+  "version": null,
+  "topologyName": "testTopology",
+  "routerSpecs": [
+    {
+      "streamId": "oozieStream",
+      "partition": {
+        "streamId": "oozieStream",
+        "type": "GROUPBY",
+        "columns": [
+          "operation"
+        ],
+        "sortSpec": {
+          "windowPeriod": "PT4S",
+          "windowMargin": 1000
+        }
+      },
+      "targetQueue": [
+        {
+          "partition": {
+            "streamId": "oozieStream",
+            "type": "GROUPBY",
+            "columns": [
+              "ip"
+            ],
+            "sortSpec": {
+              "windowPeriod": "PT4S",
+              "windowMargin": 1000
+            }
+          },
+          "workers": [
+            {
+              "topologyName": "testTopology",
+              "boltId": "alertBolt0"
+            },
+            {
+              "topologyName": "testTopology",
+              "boltId": "alertBolt1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/pom.xml
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eagle-alert</artifactId>
+        <groupId>org.apache.eagle</groupId>
+        <version>0.5.0-incubating-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>alert-spark</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>alert-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_${scala.version}</artifactId>
+            <version>${spark.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming-kafka-0-8_${scala.version}</artifactId>
+            <version>${spark.core.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.orbit</groupId>
+                    <artifactId>javax.servlet</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>${servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.jpountz.lz4</groupId>
+            <artifactId>lz4</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+                <artifactId>maven-scala-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/UnitSparkTopologyMain.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/UnitSparkTopologyMain.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine;
+
+import org.apache.eagle.alert.engine.runner.UnitSparkTopologyRunner;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+public class UnitSparkTopologyMain {
+    public static void main(String[] args) throws InterruptedException {
+        Config config = ConfigFactory.load();
+        new UnitSparkTopologyRunner(config).run();
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/runner/UnitSparkTopologyRunner.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/runner/UnitSparkTopologyRunner.java
@@ -1,0 +1,219 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.runner;
+
+import static org.apache.eagle.alert.engine.utils.SpecUtils.getTopicsByConfig;
+
+
+import org.apache.eagle.alert.coordination.model.*;
+import org.apache.eagle.alert.engine.coordinator.*;
+import org.apache.eagle.alert.engine.spark.function.*;
+import org.apache.eagle.alert.engine.spark.model.*;
+
+import kafka.common.TopicAndPartition;
+import com.typesafe.config.Config;
+import kafka.message.MessageAndMetadata;
+import kafka.serializer.StringDecoder;
+import org.apache.spark.SparkConf;
+import org.apache.spark.streaming.Durations;
+import org.apache.spark.streaming.api.java.JavaInputDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.kafka.EagleKafkaUtils;
+import org.apache.spark.streaming.kafka.KafkaCluster;
+import org.apache.spark.streaming.kafka.OffsetRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class UnitSparkTopologyRunner implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UnitSparkTopologyRunner.class);
+    //kafka config
+    private KafkaCluster kafkaCluster = null;
+    private Map<String, String> kafkaParams = new HashMap<>();
+    private Map<TopicAndPartition, Long> fromOffsets = new HashMap<>();
+    private final AtomicReference<OffsetRange[]> offsetRanges = new AtomicReference<>();
+    //common config
+    private final AtomicReference<Map<String, StreamDefinition>> sdsRef = new AtomicReference<>();
+    private final AtomicReference<SpoutSpec> spoutSpecRef = new AtomicReference<>();
+    private final AtomicReference<AlertBoltSpec> alertBoltSpecRef = new AtomicReference<>();
+    private final AtomicReference<HashSet<String>> topicsRef = new AtomicReference<>();
+    private final AtomicReference<RouterSpec> routerSpecRef = new AtomicReference<>();
+    private final AtomicReference<PublishSpec> publishSpecRef = new AtomicReference<>();
+    private String groupId;
+    //Zookeeper server string: host1:port1[,host2:port2,...]
+    private String zkServers = null;
+    //spark config
+    private static final String BATCH_DURATION = "topology.batchDuration";
+    private static final int DEFAULT_BATCH_DURATION_SECOND = 2;
+    private static final String SPARK_EXECUTOR_CORES = "topology.core";
+    private static final String SPARK_EXECUTOR_MEMORY = "topology.memory";
+    private static final String alertPublishBoltName = "alertPublishBolt";
+    private static final String LOCAL_MODE = "topology.localMode";
+    private static final String ROUTER_TASK_NUM = "topology.numOfRouterBolts";
+    private static final String ALERT_TASK_NUM = "topology.numOfAlertBolts";
+    private static final String PUBLISH_TASK_NUM = "topology.numOfPublishTasks";
+    private static final String SLIDE_DURATION_SECOND = "topology.slideDurations";
+    private static final String WINDOW_DURATIONS_SECOND = "topology.windowDurations";
+    private static final String TOPOLOGY_MASTER = "topology.master";
+    private static final String DRIVER_MEMORY = "topology.driverMemory";
+    private static final String DRIVER_CORES = "topology.driverCores";
+    private static final String DEPLOY_MODE = "topology.deployMode";
+    private static final String CHECKPOINT_PATH = "topology.checkpointPath";
+
+
+    private SparkConf sparkConf;
+
+    private final Config config;
+
+
+    public UnitSparkTopologyRunner(Config config) {
+
+        prepareKafkaConfig(config);
+        prepareSparkConfig(config);
+        this.config = config;
+        this.zkServers = config.getString("zkConfig.zkQuorum");
+
+    }
+
+    public void run() throws InterruptedException {
+        long batchDuration = config.hasPath(BATCH_DURATION) ? config.getLong(BATCH_DURATION) : DEFAULT_BATCH_DURATION_SECOND;
+        JavaStreamingContext jssc = new JavaStreamingContext(sparkConf, Durations.seconds(batchDuration));
+        jssc.checkpoint(config.getString(CHECKPOINT_PATH));
+        buildTopology(jssc, config);
+        LOG.info("Starting Spark Streaming");
+        jssc.start();
+        LOG.info("Spark Streaming is running");
+        jssc.awaitTermination();
+    }
+
+    private void buildTopology(JavaStreamingContext jssc, Config config) {
+
+        Set<String> topics = getTopicsByConfig(config);
+        EagleKafkaUtils.fillInLatestOffsets(topics,
+                this.fromOffsets,
+                this.groupId,
+                this.kafkaCluster,
+                this.zkServers);
+
+        int windowDurations = config.getInt(WINDOW_DURATIONS_SECOND);
+        int slideDurations = config.getInt(SLIDE_DURATION_SECOND);
+        int numOfRouter = config.getInt(ROUTER_TASK_NUM);
+        int numOfAlertBolts = config.getInt(ALERT_TASK_NUM);
+        int numOfPublishTasks = config.getInt(PUBLISH_TASK_NUM);
+
+        @SuppressWarnings("unchecked")
+        Class<MessageAndMetadata<String, String>> streamClass =
+                (Class<MessageAndMetadata<String, String>>) (Class<?>) MessageAndMetadata.class;
+
+        JavaInputDStream<MessageAndMetadata<String, String>> messages = EagleKafkaUtils.createDirectStream(jssc,
+                String.class,
+                String.class,
+                StringDecoder.class,
+                StringDecoder.class,
+                streamClass,
+                kafkaParams,
+                this.fromOffsets,
+                new RefreshTopicFunction(this.topicsRef, this.groupId, this.kafkaCluster, this.zkServers), message -> message);
+
+        WindowState winstate = new WindowState(jssc);
+        RouteState routeState = new RouteState(jssc);
+        PolicyState policyState = new PolicyState(jssc);
+        PublishState publishState = new PublishState(jssc);
+        SiddhiState siddhiState = new SiddhiState(jssc);
+
+        JavaPairDStream<String, String> pairDStream = messages
+                .transform(new ProcessSpecFunction(offsetRanges,
+                        spoutSpecRef,
+                        sdsRef,
+                        alertBoltSpecRef,
+                        topicsRef,
+                        routerSpecRef,
+                        config,
+                        winstate,
+                        routeState,
+                        policyState,
+                        publishState,
+                        siddhiState,
+                        publishSpecRef))
+                .mapToPair(km -> new Tuple2<>(km.topic(), km.message()));
+
+        pairDStream
+                .window(Durations.seconds(windowDurations), Durations.seconds(slideDurations))
+                .flatMapToPair(new CorrelationSpoutSparkFunction(numOfRouter, spoutSpecRef, sdsRef))
+                .transformToPair(new ChangePartitionTo(numOfRouter))
+                .mapPartitionsToPair(new StreamRouteBoltFunction("streamBolt", sdsRef, routerSpecRef, winstate, routeState))
+                .transformToPair(new ChangePartitionTo(numOfAlertBolts))
+                .mapPartitionsToPair(new AlertBoltFunction(sdsRef, alertBoltSpecRef, policyState, siddhiState))
+                .repartition(numOfPublishTasks)
+                .foreachRDD(new Publisher(alertPublishBoltName, kafkaCluster, groupId, offsetRanges, publishState, publishSpecRef));
+    }
+
+    private void prepareKafkaConfig(Config config) {
+        String inputBroker = config.getString("spout.kafkaBrokerZkQuorum");
+        this.kafkaParams.put("metadata.broker.list", inputBroker);
+        this.groupId = config.getString("topology.groupId");
+        this.kafkaParams.put("group.id", this.groupId);
+        this.kafkaParams.put("auto.offset.reset", "largest");
+        // Newer version of metadata.broker.list:
+        this.kafkaParams.put("bootstrap.servers", inputBroker);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        this.kafkaCluster = new KafkaCluster(immutableKafkaParam);
+    }
+
+    private void prepareSparkConfig(Config config) {
+        SparkConf sparkConf = new SparkConf();
+        sparkConf.setAppName(config.getString("topology.name"));
+        boolean localMode = config.getBoolean(LOCAL_MODE);
+        if (localMode) {
+            LOG.info("Submitting as local mode");
+            sparkConf.setMaster("local[*]");
+        } else {
+            sparkConf.setMaster(config.getString(TOPOLOGY_MASTER));
+        }
+        String sparkExecutorCores = config.getString(SPARK_EXECUTOR_CORES);
+        String sparkExecutorMemory = config.getString(SPARK_EXECUTOR_MEMORY);
+        String driverMemory = config.getString(DRIVER_MEMORY);
+        String driverCore = config.getString(DRIVER_CORES);
+        String deployMode = config.getString(DEPLOY_MODE);
+        sparkConf.set("spark.executor.cores", sparkExecutorCores);
+        sparkConf.set("spark.executor.memory", sparkExecutorMemory);
+        sparkConf.set("spark.driver.memory", driverMemory);
+        sparkConf.set("spark.driver.cores", driverCore);
+        sparkConf.set("spark.submit.deployMode", deployMode);
+        sparkConf.set("spark.streaming.dynamicAllocation.enable", "true");
+
+        this.sparkConf = sparkConf;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/runner/UnitSparkTopologyRunner.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/runner/UnitSparkTopologyRunner.java
@@ -157,7 +157,8 @@ public class UnitSparkTopologyRunner implements Serializable {
                         policyState,
                         publishState,
                         siddhiState,
-                        publishSpecRef))
+                        publishSpecRef,
+                        numOfAlertBolts))
                 .mapToPair(km -> new Tuple2<>(km.topic(), km.message()));
 
         pairDStream

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/accumulator/MapAccum.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/accumulator/MapAccum.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.accumulator;
+
+import org.apache.spark.AccumulatorParam;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapAccum<T, K, V> implements AccumulatorParam<Map<T, Map<K, V>>> {
+    @Override
+    public Map<T, Map<K, V>> addAccumulator(Map<T, Map<K, V>> t1, Map<T, Map<K, V>> t2) {
+        return mergeMap(t1, t2);
+    }
+
+    @Override
+    public Map<T, Map<K, V>> addInPlace(Map<T, Map<K, V>> r1, Map<T, Map<K, V>> r2) {
+        return mergeMap(r1, r2);
+
+    }
+
+    @Override
+    public Map<T, Map<K, V>> zero(final Map<T, Map<K, V>> initialValue) {
+        return new HashMap<>();
+    }
+
+    private Map<T, Map<K, V>> mergeMap(Map<T, Map<K, V>> map1, Map<T, Map<K, V>> map2) {
+        Map<T, Map<K, V>> result = new HashMap<>(map1);
+        map2.forEach((k, v) -> result.merge(k, v, (a, b) -> b));
+        return result;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/AlertBoltFunction.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/AlertBoltFunction.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import backtype.storm.metric.api.MultiCountMetric;
+import org.apache.eagle.alert.coordination.model.AlertBoltSpec;
+import org.apache.eagle.alert.engine.StreamContextImpl;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.evaluator.CompositePolicyHandler;
+import org.apache.eagle.alert.engine.evaluator.PolicyGroupEvaluator;
+import org.apache.eagle.alert.engine.evaluator.PolicyStreamHandler;
+import org.apache.eagle.alert.engine.evaluator.impl.AlertBoltOutputCollectorSparkWrapper;
+import org.apache.eagle.alert.engine.evaluator.impl.PolicyGroupEvaluatorImpl;
+import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+import org.apache.eagle.alert.engine.model.PartitionedEvent;
+import org.apache.eagle.alert.engine.runner.MapComparator;
+import org.apache.eagle.alert.engine.spark.model.PolicyState;
+import org.apache.eagle.alert.engine.spark.model.SiddhiState;
+import org.apache.eagle.alert.engine.utils.Constants;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AlertBoltFunction implements PairFlatMapFunction<Iterator<Tuple2<Integer, PartitionedEvent>>, String, AlertStreamEvent> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlertBoltFunction.class);
+    private AtomicReference<Map<String, StreamDefinition>> sdsRef;
+    private AtomicReference<AlertBoltSpec> alertBoltSpecRef;
+    private PolicyState policyState;
+    private SiddhiState siddhiState;
+
+    public AlertBoltFunction(AtomicReference<Map<String, StreamDefinition>> sdsRef, AtomicReference<AlertBoltSpec> alertBoltSpecRef, PolicyState policyState, SiddhiState siddhiState) {
+        this.sdsRef = sdsRef;
+        this.alertBoltSpecRef = alertBoltSpecRef;
+        this.policyState = policyState;
+        this.siddhiState = siddhiState;
+    }
+
+    @Override
+    public Iterator<Tuple2<String, AlertStreamEvent>> call(Iterator<Tuple2<Integer, PartitionedEvent>> tuple2Iterator) throws Exception {
+
+        PolicyGroupEvaluatorImpl policyGroupEvaluator = null;
+        AlertBoltOutputCollectorSparkWrapper alertOutputCollector = null;
+        AlertBoltSpec spec;
+        Map<String, StreamDefinition> sds;
+        int partitionNum = Constants.UNKNOW_PARTITION;
+        String boltId = Constants.ALERTBOLTNAME_PREFIX + partitionNum;
+        while (tuple2Iterator.hasNext()) {
+            Tuple2<Integer, PartitionedEvent> tuple2 = tuple2Iterator.next();
+            if (partitionNum == Constants.UNKNOW_PARTITION) {
+                partitionNum = tuple2._1;
+            }
+            if (policyGroupEvaluator == null) {
+                spec = alertBoltSpecRef.get();
+                sds = sdsRef.get();
+                boltId = Constants.ALERTBOLTNAME_PREFIX + partitionNum;
+                policyGroupEvaluator = new PolicyGroupEvaluatorImpl(boltId + "-evaluator_stage1");
+                alertOutputCollector = new AlertBoltOutputCollectorSparkWrapper();
+                //TODO StreamContext need to be more abstract
+                Map<String, PolicyDefinition> policyDefinitionMap = policyState.getPolicyDefinitionByBoltId(boltId);
+                Map<String, CompositePolicyHandler> policyStreamHandlerMap = policyState.getPolicyStreamHandlerByBoltId(boltId);
+                byte[] siddhiSnapShot = siddhiState.getSiddhiSnapShotByBoltIdAndPartitionNum(boltId, partitionNum);
+                policyGroupEvaluator.init(new StreamContextImpl(null, new MultiCountMetric(), null), alertOutputCollector, policyDefinitionMap, policyStreamHandlerMap, siddhiSnapShot);
+                onAlertBoltSpecChange(boltId, spec, sds, policyGroupEvaluator, policyState);
+            }
+            PartitionedEvent event = tuple2._2;
+            policyGroupEvaluator.nextEvent(event);
+        }
+
+        cleanup(policyGroupEvaluator, alertOutputCollector, boltId, partitionNum);
+        if (alertOutputCollector == null) {
+            return Collections.emptyIterator();
+        }
+        return alertOutputCollector.emitResult().iterator();
+    }
+
+    private void onAlertBoltSpecChange(String boltId, AlertBoltSpec spec, Map<String, StreamDefinition> sds, PolicyGroupEvaluatorImpl policyGroupEvaluator, PolicyState policyState) {
+        List<PolicyDefinition> newPolicies = spec.getBoltPoliciesMap().get(boltId);
+        LOG.debug("newPolicies {}", newPolicies);
+        if (newPolicies == null) {
+            LOG.info("no new policy with AlertBoltSpec {} for this bolt {}", spec, boltId);
+            return;
+        }
+
+        Map<String, PolicyDefinition> newPoliciesMap = new HashMap<>();
+        newPolicies.forEach(p -> newPoliciesMap.put(p.getName(), p));
+        LOG.debug("newPoliciesMap {}", newPoliciesMap);
+        MapComparator<String, PolicyDefinition> comparator = new MapComparator<>(newPoliciesMap, policyState.getCachedPolicyByBoltId(boltId));
+        comparator.compare();
+        LOG.debug("cachedPolicies {}", policyState.getCachedPolicyByBoltId(boltId));
+        LOG.debug("getAdded {}", comparator.getAdded());
+        LOG.debug("getRemoved {}", comparator.getRemoved());
+        LOG.debug("getModified {}", comparator.getModified());
+        policyGroupEvaluator.onPolicyChange(comparator.getAdded(), comparator.getRemoved(), comparator.getModified(), sds);
+
+        policyState.store(boltId, newPoliciesMap, policyGroupEvaluator.getPolicyDefinitionMap(), policyGroupEvaluator.getPolicyStreamHandlerMap());
+    }
+
+    public void cleanup(PolicyGroupEvaluatorImpl policyGroupEvaluator, AlertBoltOutputCollectorSparkWrapper alertOutputCollector, String boltId, int partitionNum) {
+        if (policyGroupEvaluator != null) {
+            siddhiState.store(policyGroupEvaluator.closeAndSnapShot(), boltId, partitionNum);
+        }
+        if (alertOutputCollector != null) {
+            alertOutputCollector.flush();
+            alertOutputCollector.close();
+        }
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/AlertPublisherBoltFunction.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/AlertPublisherBoltFunction.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import org.apache.eagle.alert.coordination.model.PublishSpec;
+import org.apache.eagle.alert.engine.coordinator.Publishment;
+import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+import org.apache.eagle.alert.engine.publisher.AlertPublisher;
+import org.apache.eagle.alert.engine.publisher.impl.AlertPublisherImpl;
+import org.apache.eagle.alert.engine.runner.MapComparator;
+import org.apache.eagle.alert.engine.spark.model.PublishState;
+import org.apache.eagle.alert.engine.utils.Constants;
+
+import org.apache.spark.api.java.function.VoidFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AlertPublisherBoltFunction implements VoidFunction<Iterator<Tuple2<String, AlertStreamEvent>>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlertPublisherBoltFunction.class);
+    private String alertPublishBoltName = "alertPublishBolt";
+    private AtomicReference<PublishSpec> publishSpecRef;
+    private PublishState publishState;
+    private Map<String, Publishment> cachedPublishments = new HashMap<>();
+
+
+    public AlertPublisherBoltFunction(AtomicReference<PublishSpec> publishSpecRef, String alertPublishBoltName, PublishState publishState) {
+        this.alertPublishBoltName = alertPublishBoltName;
+        this.publishSpecRef = publishSpecRef;
+        this.publishState = publishState;
+    }
+
+    @Override
+    public void call(Iterator<Tuple2<String, AlertStreamEvent>> tuple2Iterator) throws Exception {
+        PublishSpec publishSpec;
+        AlertPublisherImpl alertPublisher = null;
+        String streamId = Constants.UNKNOW_STREAMID;
+        while (tuple2Iterator.hasNext()) {
+            Tuple2<String, AlertStreamEvent> tuple2 = tuple2Iterator.next();
+            if (streamId == Constants.UNKNOW_STREAMID) {
+                streamId = tuple2._1;
+            }
+            if (alertPublisher == null) {
+                cachedPublishments = publishState.getCachedPublishmentsByStreamId(streamId);
+                alertPublisher = new AlertPublisherImpl(alertPublishBoltName, new ArrayList<>(cachedPublishments.values()));
+                alertPublisher.init(null, new HashMap<>());
+                publishSpec = publishSpecRef.get();
+
+                onAlertPublishSpecChange(alertPublisher, publishSpec, cachedPublishments);
+                publishState.store(streamId, cachedPublishments);
+            }
+            AlertStreamEvent alertEvent = tuple2._2;
+            LOG.info("AlertPublisherBoltFunction " + alertEvent);
+            alertPublisher.nextEvent(alertEvent);
+        }
+        if (alertPublisher != null) {
+            alertPublisher.close();
+        }
+    }
+
+    private void onAlertPublishSpecChange(AlertPublisher alertPublisher, PublishSpec pubSpec, final Map<String, Publishment> cachedPublishments) {
+        if (pubSpec == null) {
+            return;
+        }
+
+        List<Publishment> newPublishments = pubSpec.getPublishments();
+        if (newPublishments == null) {
+            LOG.info("no publishments with PublishSpec {} for this topology", pubSpec);
+            return;
+        }
+        Map<String, Publishment> newPublishmentsMap = new HashMap<>();
+        newPublishments.forEach(p -> newPublishmentsMap.put(p.getName(), p));
+        MapComparator<String, Publishment> comparator = new MapComparator<>(newPublishmentsMap, cachedPublishments);
+        comparator.compare();
+        List<Publishment> beforeModified = new ArrayList<>();
+        comparator.getModified().forEach(p -> beforeModified.add(cachedPublishments.get(p.getName())));
+        alertPublisher.onPublishChange(comparator.getAdded(), comparator.getRemoved(), comparator.getModified(), beforeModified);
+        this.cachedPublishments = newPublishmentsMap;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/ChangePartitionTo.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/ChangePartitionTo.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import org.apache.eagle.alert.engine.model.PartitionedEvent;
+import org.apache.eagle.alert.engine.spark.partition.StreamRoutePartitioner;
+
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.function.Function;
+
+public class ChangePartitionTo implements Function<JavaPairRDD<Integer, PartitionedEvent>, JavaPairRDD<Integer, PartitionedEvent>> {
+    private int numParts;
+
+    public ChangePartitionTo(int numParts) {
+        this.numParts = numParts;
+    }
+
+    @Override
+    public JavaPairRDD<Integer, PartitionedEvent> call(JavaPairRDD<Integer, PartitionedEvent> rdd) throws Exception {
+        return rdd.partitionBy(new StreamRoutePartitioner(numParts));
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/CorrelationSpoutSparkFunction.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/CorrelationSpoutSparkFunction.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.eagle.alert.coordination.model.*;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.engine.model.PartitionedEvent;
+import org.apache.eagle.alert.engine.model.StreamEvent;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CorrelationSpoutSparkFunction implements PairFlatMapFunction<Tuple2<String, String>, Integer, PartitionedEvent> {
+
+    private static final long serialVersionUID = -5281723341236671580L;
+    private static final Logger LOG = LoggerFactory.getLogger(CorrelationSpoutSparkFunction.class);
+
+    private int numOfRouterBolts;
+    private AtomicReference<SpoutSpec> spoutSpecRef;
+    private AtomicReference<Map<String, StreamDefinition>> sdsRef;
+
+    public CorrelationSpoutSparkFunction(int numOfRouter, AtomicReference<SpoutSpec> spoutSpecRef, AtomicReference<Map<String, StreamDefinition>> sdsRef) {
+        this.numOfRouterBolts = numOfRouter;
+        this.spoutSpecRef = spoutSpecRef;
+        this.sdsRef = sdsRef;
+    }
+
+    @Override
+    public Iterator<Tuple2<Integer, PartitionedEvent>> call(Tuple2<String, String> message) {
+
+        ObjectMapper mapper = new ObjectMapper();
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
+        };
+        Map<String, Object> value;
+        try {
+            value = mapper.readValue(message._2, typeRef);
+        } catch (IOException e) {
+            LOG.info("covert tuple value to map error");
+            return Collections.emptyIterator();
+        }
+        List<Object> tuple = new ArrayList<>(2);
+        String topic = message._1;
+        tuple.add(0, topic);
+        tuple.add(1, value);
+        SpoutSpec spoutSpec = spoutSpecRef.get();
+        Tuple2StreamMetadata metadata = spoutSpec.getTuple2StreamMetadataMap().get(topic);
+        if (metadata == null) {
+            LOG.info(
+                    "tuple2StreamMetadata is null spout collector for topic {} see monitored metadata invalid, is this data source removed! ", topic);
+            return Collections.emptyIterator();
+        }
+        Tuple2StreamConverter converter = new Tuple2StreamConverter(metadata);
+        List<Object> tupleContent = converter.convert(tuple);
+
+        List<StreamRepartitionMetadata> streamRepartitionMetadataList = spoutSpec.getStreamRepartitionMetadataMap().get(topic);
+        if (streamRepartitionMetadataList == null) {
+            LOG.info(
+                    "streamRepartitionMetadataList is nullspout collector for topic {} see monitored metadata invalid, is this data source removed! ", topic);
+            return Collections.emptyIterator();
+        }
+        Map<String, Object> messageContent = (Map<String, Object>) tupleContent.get(3);
+        Object streamId = tupleContent.get(1);
+        Map<String, StreamDefinition> sds = sdsRef.get();
+        StreamDefinition sd = sds.get(streamId);
+        if (sd == null) {
+            LOG.info("StreamDefinition {} is not found within {}, ignore this message", streamId, sds);
+            return Collections.emptyIterator();
+        }
+        List<Tuple2<Integer, PartitionedEvent>> outputTuple2s = new ArrayList<>(5);
+
+        Long timestamp = (Long) tupleContent.get(2);
+        StreamEvent event = convertToStreamEventByStreamDefinition(timestamp, messageContent, sds.get(streamId));
+
+        for (StreamRepartitionMetadata md : streamRepartitionMetadataList) {
+            // one stream may have multiple group-by strategies, each strategy is for a specific group-by
+            for (StreamRepartitionStrategy groupingStrategy : md.groupingStrategies) {
+                int hash = 0;
+                if (groupingStrategy.getPartition().getType().equals(StreamPartition.Type.GROUPBY)) {
+                    hash = getRoutingHashByGroupingStrategy(messageContent, groupingStrategy);
+                } else if (groupingStrategy.getPartition().getType().equals(StreamPartition.Type.SHUFFLE)) {
+                    hash = Math.abs((int) System.currentTimeMillis());
+                }
+                int mod = hash % groupingStrategy.numTotalParticipatingRouterBolts;
+                // filter out message
+                if (mod >= groupingStrategy.startSequence && mod < groupingStrategy.startSequence + numOfRouterBolts) {
+                    PartitionedEvent pEvent = new PartitionedEvent(event, groupingStrategy.partition, hash);
+                    outputTuple2s.add(new Tuple2<>(mod, pEvent));
+                }
+            }
+        }
+        if (CollectionUtils.isEmpty(outputTuple2s)) {
+            return Collections.emptyIterator();
+        }
+        return outputTuple2s.iterator();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private int getRoutingHashByGroupingStrategy(Map data, StreamRepartitionStrategy gs) {
+        // calculate hash value for values from group-by fields
+        HashCodeBuilder hashCodeBuilder = new HashCodeBuilder();
+        for (String groupingField : gs.partition.getColumns()) {
+            if (data.get(groupingField) != null) {
+                hashCodeBuilder.append(data.get(groupingField));
+            } else {
+                LOG.warn("Required GroupBy fields {} not found: {}", gs.partition.getColumns(), data);
+            }
+        }
+        int hash = hashCodeBuilder.toHashCode();
+        hash = Math.abs(hash);
+        return hash;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private StreamEvent convertToStreamEventByStreamDefinition(long timestamp, Map messageContent, StreamDefinition sd) {
+        return StreamEvent.builder().timestamep(timestamp).attributes(messageContent, sd).build();
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/ProcessSpecFunction.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/ProcessSpecFunction.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import com.typesafe.config.Config;
+import kafka.message.MessageAndMetadata;
+import org.apache.eagle.alert.coordination.model.AlertBoltSpec;
+import org.apache.eagle.alert.coordination.model.PublishSpec;
+import org.apache.eagle.alert.coordination.model.RouterSpec;
+import org.apache.eagle.alert.coordination.model.SpoutSpec;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.spark.model.*;
+import org.apache.eagle.alert.service.SpecMetadataServiceClientImpl;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.streaming.kafka.HasOffsetRanges;
+import org.apache.spark.streaming.kafka.OffsetRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.eagle.alert.engine.utils.SpecUtils.getTopicsBySpoutSpec;
+
+public class ProcessSpecFunction implements Function<JavaRDD<MessageAndMetadata<String, String>>, JavaRDD<MessageAndMetadata<String, String>>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessSpecFunction.class);
+
+    private SpecMetadataServiceClientImpl client;
+    private AtomicReference<OffsetRange[]> offsetRanges;
+    private AtomicReference<SpoutSpec> spoutSpecRef;
+    private AtomicReference<PublishSpec> publishSpecRef;
+    private AtomicReference<RouterSpec> routerSpecRef;
+    private AtomicReference<AlertBoltSpec> alertBoltSpecRef;
+    private AtomicReference<Map<String, StreamDefinition>> sdsRef;
+    private AtomicReference<HashSet<String>> topicsRef;
+
+
+    private RouteState routeState;
+    private WindowState winstate;
+    private PolicyState policyState;
+    private PublishState publishState;
+    private SiddhiState siddhiState;
+
+    public ProcessSpecFunction(AtomicReference<OffsetRange[]> offsetRanges, AtomicReference<SpoutSpec> spoutSpecRef,
+                               AtomicReference<Map<String, StreamDefinition>> sdsRef, AtomicReference<AlertBoltSpec> alertBoltSpecRef,
+                               AtomicReference<HashSet<String>> topicsRef, AtomicReference<RouterSpec> routerSpecRef,
+                               Config config, WindowState windowState, RouteState routeState, PolicyState policyState,
+                               PublishState publishState, SiddhiState siddhiState, AtomicReference<PublishSpec> publishSpecRef
+    ) {
+        this.offsetRanges = offsetRanges;
+        this.spoutSpecRef = spoutSpecRef;
+        this.alertBoltSpecRef = alertBoltSpecRef;
+        this.routerSpecRef = routerSpecRef;
+        this.publishSpecRef = publishSpecRef;
+        this.topicsRef = topicsRef;
+        this.client = new SpecMetadataServiceClientImpl(config);
+        this.sdsRef = sdsRef;
+        this.winstate = windowState;
+        this.routeState = routeState;
+        this.policyState = policyState;
+        this.publishState = publishState;
+        this.siddhiState = siddhiState;
+    }
+
+    @Override
+    public JavaRDD<MessageAndMetadata<String, String>> call(JavaRDD<MessageAndMetadata<String, String>> rdd) throws Exception {
+
+        SpoutSpec spoutSpec = client.getSpoutSpec();
+        spoutSpecRef.set(spoutSpec);
+        AlertBoltSpec alertBoltSpec = client.getAlertBoltSpec();
+        alertBoltSpecRef.set(alertBoltSpec);
+        //Fix always get getModified policy
+        alertBoltSpec.getBoltPoliciesMap().values().forEach((policyDefinitions) -> policyDefinitions.forEach(policy -> {
+                    policy.getDefinition().setInputStreams(policy.getInputStreams());
+                    policy.getDefinition().setOutputStreams(policy.getOutputStreams());
+                }
+
+                )
+        );
+        sdsRef.set(client.getSds());
+        publishSpecRef.set(client.getPublishSpec());
+        routerSpecRef.set(client.getRouterSpec());
+
+        loadTopics(spoutSpec);
+        updateOffsetRanges(rdd);
+        recoverState();
+
+        return rdd;
+    }
+
+    private void recoverState() {
+        winstate.recover();
+        routeState.recover();
+        policyState.recover();
+        publishState.recover();
+        siddhiState.recover();
+    }
+
+    private void updateOffsetRanges(JavaRDD<MessageAndMetadata<String, String>> rdd) {
+        OffsetRange[] offsets = ((HasOffsetRanges) rdd.rdd()).offsetRanges();
+        offsetRanges.set(offsets);
+    }
+
+
+    private void loadTopics(SpoutSpec spoutSpec) {
+        Set<String> newTopics = getTopicsBySpoutSpec(spoutSpec);
+        Set<String> oldTopics = topicsRef.get();
+        LOG.info("Topics were old={}, new={}", oldTopics, newTopics);
+        topicsRef.set(new HashSet<>(newTopics));
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/Publisher.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/Publisher.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import org.apache.eagle.alert.coordination.model.PublishSpec;
+import org.apache.eagle.alert.engine.coordinator.Publishment;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+
+import kafka.common.TopicAndPartition;
+import org.apache.eagle.alert.engine.spark.model.PublishState;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.function.VoidFunction;
+import org.apache.spark.streaming.kafka.KafkaCluster;
+import org.apache.spark.streaming.kafka.OffsetRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Publisher implements VoidFunction<JavaPairRDD<String, AlertStreamEvent>> {
+
+    private String alertPublishBoltName;
+    private KafkaCluster kafkaCluster;
+    private String groupId;
+    private AtomicReference<OffsetRange[]> offsetRanges;
+    private AtomicReference<PublishSpec> publishSpecRef;
+    private PublishState publishState;
+    private static final Logger LOG = LoggerFactory.getLogger(Publisher.class);
+
+    public Publisher(String alertPublishBoltName, KafkaCluster kafkaCluster, String groupId, AtomicReference<OffsetRange[]> offsetRanges,
+                     PublishState publishState, AtomicReference<PublishSpec> publishSpecRef) {
+        this.alertPublishBoltName = alertPublishBoltName;
+        this.kafkaCluster = kafkaCluster;
+        this.groupId = groupId;
+        this.offsetRanges = offsetRanges;
+        this.publishSpecRef = publishSpecRef;
+        this.publishState = publishState;
+    }
+
+    @Override
+    public void call(JavaPairRDD<String, AlertStreamEvent> rdd) throws Exception {
+        rdd.foreachPartition(new AlertPublisherBoltFunction(publishSpecRef, alertPublishBoltName, publishState));
+        updateOffset();
+    }
+
+    private void updateOffset() {
+        for (OffsetRange eachOffsetRange : offsetRanges.get()) {
+            TopicAndPartition topicAndPartition = new TopicAndPartition(eachOffsetRange.topic(), eachOffsetRange.partition());
+            Map<TopicAndPartition, Object> topicAndPartitionObjectMap = new HashMap<>();
+            topicAndPartitionObjectMap.put(topicAndPartition, eachOffsetRange.untilOffset());
+
+            scala.collection.mutable.Map<TopicAndPartition, Object> map = JavaConversions.mapAsScalaMap(topicAndPartitionObjectMap);
+            scala.collection.immutable.Map<TopicAndPartition, Object> scalatopicAndPartitionObjectMap =
+                    map.toMap(new Predef.$less$colon$less<Tuple2<TopicAndPartition, Object>, Tuple2<TopicAndPartition, Object>>() {
+                        public Tuple2<TopicAndPartition, Object> apply(Tuple2<TopicAndPartition, Object> v1) {
+                            return v1;
+                        }
+                    });
+            LOG.info("Updating offsets: {}", scalatopicAndPartitionObjectMap);
+            kafkaCluster.setConsumerOffsets(groupId, scalatopicAndPartitionObjectMap);
+        }
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/RefreshTopicFunction.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/RefreshTopicFunction.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import kafka.common.TopicAndPartition;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.streaming.kafka.EagleKafkaUtils;
+import org.apache.spark.streaming.kafka.KafkaCluster;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class RefreshTopicFunction implements Function<scala.collection.immutable.Map<TopicAndPartition, Object>, scala.collection.immutable.Map<TopicAndPartition, Object>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RefreshTopicFunction.class);
+    private AtomicReference<HashSet<String>> topicsRef = new AtomicReference<>();
+    private String groupId;
+    private KafkaCluster kafkaCluster;
+    private String zkServers;
+
+    public RefreshTopicFunction(AtomicReference<HashSet<String>> topicsRef, String groupId, KafkaCluster kafkaCluster, String zkServers) {
+        this.topicsRef = topicsRef;
+        this.groupId = groupId;
+        this.kafkaCluster = kafkaCluster;
+        this.zkServers = zkServers;
+    }
+
+    @Override
+    public scala.collection.immutable.Map<TopicAndPartition, Object> call(scala.collection.immutable.Map<TopicAndPartition, Object> oldOffset) throws Exception {
+
+        LOG.info("-------offset---OLD--" + oldOffset);
+
+        Map<TopicAndPartition, Object> oldOffsetJavaMap = JavaConversions.mapAsJavaMap(oldOffset);
+
+        Map<TopicAndPartition, Long> oldOffsetWithTypeMap = new HashMap<>(oldOffsetJavaMap.size());
+        oldOffsetJavaMap.forEach((topicAndPartition, offset) -> oldOffsetWithTypeMap.put(topicAndPartition, Long.parseLong(offset.toString())));
+
+        Map<TopicAndPartition, Object> newOffset = EagleKafkaUtils.refreshOffsets(topicsRef.get(),
+                oldOffsetWithTypeMap,
+                this.groupId,
+                this.kafkaCluster,
+                this.zkServers);
+        if (newOffset == null) {
+            LOG.info("first init app so remain the oldOffset");
+            return oldOffset;
+        }
+        scala.collection.mutable.Map<TopicAndPartition, Object> mutableNewOffsetJavaMap = JavaConversions
+                .mapAsScalaMap(newOffset);
+        scala.collection.immutable.Map<TopicAndPartition, Object> immutableNewOffsetJavaMap = mutableNewOffsetJavaMap
+                .toMap(new Predef.$less$colon$less<Tuple2<TopicAndPartition, Object>, Tuple2<TopicAndPartition, Object>>() {
+                    public Tuple2<TopicAndPartition, Object> apply(
+                            Tuple2<TopicAndPartition, Object> v1) {
+                        return v1;
+                    }
+                });
+        LOG.info("-------offset---NEW----" + immutableNewOffsetJavaMap);
+        return immutableNewOffsetJavaMap;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/StreamRouteBoltFunction.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/function/StreamRouteBoltFunction.java
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.function;
+
+import backtype.storm.metric.api.MultiCountMetric;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.eagle.alert.coordination.model.PolicyWorkerQueue;
+import org.apache.eagle.alert.coordination.model.RouterSpec;
+import org.apache.eagle.alert.coordination.model.StreamRouterSpec;
+import org.apache.eagle.alert.engine.StreamContextImpl;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.engine.coordinator.StreamSortSpec;
+import org.apache.eagle.alert.engine.model.PartitionedEvent;
+import org.apache.eagle.alert.engine.router.StreamRoutePartitioner;
+import org.apache.eagle.alert.engine.router.StreamRouter;
+import org.apache.eagle.alert.engine.router.StreamSortHandler;
+import org.apache.eagle.alert.engine.router.impl.SparkStreamRouterBoltOutputCollector;
+import org.apache.eagle.alert.engine.router.impl.StreamRouterImpl;
+import org.apache.eagle.alert.engine.sorter.StreamTimeClock;
+import org.apache.eagle.alert.engine.sorter.StreamTimeClockListener;
+import org.apache.eagle.alert.engine.spark.model.RouteState;
+import org.apache.eagle.alert.engine.spark.model.WindowState;
+import org.apache.eagle.alert.engine.utils.Constants;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class StreamRouteBoltFunction implements PairFlatMapFunction<Iterator<Tuple2<Integer, PartitionedEvent>>, Integer, PartitionedEvent> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamRouteBoltFunction.class);
+    private static final long serialVersionUID = -7211470889316430372L;
+    private AtomicReference<Map<String, StreamDefinition>> sdsRef;
+    private AtomicReference<RouterSpec> routerSpecRef;
+
+    // mapping from StreamPartition to StreamSortSpec
+    private Map<StreamPartition, StreamSortSpec> cachedSSS = new HashMap<>();
+    // mapping from StreamPartition(streamId, groupbyspec) to StreamRouterSpec
+    private Map<StreamPartition, StreamRouterSpec> cachedSRS = new HashMap<>();
+
+    private WindowState winstate;
+    private RouteState routeState;
+    private String routeName;
+
+    public StreamRouteBoltFunction(String routeName, AtomicReference<Map<String, StreamDefinition>> sdsRef, AtomicReference<RouterSpec> routerSpecRef, WindowState winstate, RouteState routeState) {
+        this.routeName = routeName;
+        this.sdsRef = sdsRef;
+        this.winstate = winstate;
+        this.routeState = routeState;
+        this.routerSpecRef = routerSpecRef;
+    }
+
+    @Override
+    public Iterator<Tuple2<Integer, PartitionedEvent>> call(Iterator<Tuple2<Integer, PartitionedEvent>> tuple2Iterator) throws Exception {
+
+
+        Map<String, StreamDefinition> sdf;
+        RouterSpec spec;
+        SparkStreamRouterBoltOutputCollector routeCollector = null;
+        StreamRouterImpl router = null;
+
+        int partitionNum = Constants.UNKNOW_PARTITION;
+
+        while (tuple2Iterator.hasNext()) {
+
+            Tuple2<Integer, PartitionedEvent> tuple2 = tuple2Iterator.next();
+            if (partitionNum == Constants.UNKNOW_PARTITION) {
+                partitionNum = tuple2._1;
+            }
+
+            if (router == null) {
+                sdf = sdsRef.get();
+                spec = routerSpecRef.get();
+
+                router = new StreamRouterImpl(routeName);
+                Map<StreamPartition, StreamRouterSpec> routeSpecMap = routeState.getRouteSpecMapByPartition(partitionNum);
+                Map<StreamPartition, List<StreamRoutePartitioner>> routePartitionerMap = routeState.getRoutePartitionerByPartition(partitionNum);
+                cachedSSS = routeState.getCachedSSSMapByPartition(partitionNum);
+                cachedSRS = routeState.getCachedSRSMapByPartition(partitionNum);
+                routeCollector = new SparkStreamRouterBoltOutputCollector(routeSpecMap, routePartitionerMap);
+                Map<String, StreamTimeClock> streamTimeClockMap = winstate.getStreamTimeClockByPartition(partitionNum);
+                Map<StreamTimeClockListener, String> streamWindowMap = winstate.getStreamWindowsByPartition(partitionNum);
+                Map<StreamPartition, StreamSortHandler> streamSortHandlerMap = winstate.getStreamSortHandlerByPartition(partitionNum);
+
+                router.prepare(new StreamContextImpl(null, new MultiCountMetric(), null), routeCollector, streamWindowMap, streamTimeClockMap, streamSortHandlerMap);
+                onStreamRouteBoltSpecChange(spec, sdf, router, routeCollector, cachedSSS, cachedSRS);
+            }
+
+            PartitionedEvent partitionedEvent = tuple2._2;
+            router.nextEvent(partitionedEvent);
+        }
+        cleanup(router);
+        if (partitionNum != Constants.UNKNOW_PARTITION) {
+            winstate.store(router, partitionNum);
+            routeState.store(routeCollector, cachedSSS, cachedSRS, partitionNum);
+        }
+        if (routeCollector == null) {
+            return Collections.emptyIterator();
+        }
+        return routeCollector.emitResult().iterator();
+    }
+
+    public void cleanup(StreamRouter router) {
+        if (router != null) {
+            StreamRouterImpl routerImpl = (StreamRouterImpl) router;
+            routerImpl.closeClock();
+        }
+    }
+
+    public void onStreamRouteBoltSpecChange(RouterSpec spec, Map<String, StreamDefinition> sds, StreamRouterImpl router, SparkStreamRouterBoltOutputCollector routeCollector,
+                                            final Map<StreamPartition, StreamSortSpec> cachedSSS, final Map<StreamPartition, StreamRouterSpec> cachedSRS) {
+        //sanityCheck(spec);
+
+        // figure out added, removed, modified StreamSortSpec
+        Map<StreamPartition, StreamSortSpec> newSSS = new HashMap<>();
+        spec.getRouterSpecs().forEach(t -> {
+            if (t.getPartition().getSortSpec() != null) {
+                newSSS.put(t.getPartition(), t.getPartition().getSortSpec());
+            }
+        });
+
+        Set<StreamPartition> newStreamIds = newSSS.keySet();
+        Set<StreamPartition> cachedStreamIds = cachedSSS.keySet();
+        Collection<StreamPartition> addedStreamIds = CollectionUtils.subtract(newStreamIds, cachedStreamIds);
+        Collection<StreamPartition> removedStreamIds = CollectionUtils.subtract(cachedStreamIds, newStreamIds);
+        Collection<StreamPartition> modifiedStreamIds = CollectionUtils.intersection(newStreamIds, cachedStreamIds);
+
+        Map<StreamPartition, StreamSortSpec> added = new HashMap<>();
+        Map<StreamPartition, StreamSortSpec> removed = new HashMap<>();
+        Map<StreamPartition, StreamSortSpec> modified = new HashMap<>();
+        addedStreamIds.forEach(s -> added.put(s, newSSS.get(s)));
+        removedStreamIds.forEach(s -> removed.put(s, cachedSSS.get(s)));
+        modifiedStreamIds.forEach(s -> {
+            if (!newSSS.get(s).equals(cachedSSS.get(s))) { // this means StreamSortSpec is changed for one specific streamId
+                modified.put(s, newSSS.get(s));
+            }
+        });
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("added StreamSortSpec " + added);
+            LOG.debug("removed StreamSortSpec " + removed);
+            LOG.debug("modified StreamSortSpec " + modified);
+        }
+        router.onStreamSortSpecChange(added, removed, modified);
+        // switch cache
+        this.cachedSSS = newSSS;
+
+        // figure out added, removed, modified StreamRouterSpec
+        Map<StreamPartition, StreamRouterSpec> newSRS = new HashMap<>();
+        spec.getRouterSpecs().forEach(t -> newSRS.put(t.getPartition(), t));
+
+        Set<StreamPartition> newStreamPartitions = newSRS.keySet();
+        Set<StreamPartition> cachedStreamPartitions = cachedSRS.keySet();
+
+        Collection<StreamPartition> addedStreamPartitions = CollectionUtils.subtract(newStreamPartitions, cachedStreamPartitions);
+        Collection<StreamPartition> removedStreamPartitions = CollectionUtils.subtract(cachedStreamPartitions, newStreamPartitions);
+        Collection<StreamPartition> modifiedStreamPartitions = CollectionUtils.intersection(newStreamPartitions, cachedStreamPartitions);
+
+        Collection<StreamRouterSpec> addedRouterSpecs = new ArrayList<>();
+        Collection<StreamRouterSpec> removedRouterSpecs = new ArrayList<>();
+        Collection<StreamRouterSpec> modifiedRouterSpecs = new ArrayList<>();
+        addedStreamPartitions.forEach(s -> addedRouterSpecs.add(newSRS.get(s)));
+        removedStreamPartitions.forEach(s -> removedRouterSpecs.add(cachedSRS.get(s)));
+        modifiedStreamPartitions.forEach(s -> {
+            if (!newSRS.get(s).equals(cachedSRS.get(s))) { // this means StreamRouterSpec is changed for one specific StreamPartition
+                modifiedRouterSpecs.add(newSRS.get(s));
+            }
+        });
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("added StreamRouterSpec " + addedRouterSpecs);
+            LOG.debug("removed StreamRouterSpec " + removedRouterSpecs);
+            LOG.debug("modified StreamRouterSpec " + modifiedRouterSpecs);
+        }
+
+        routeCollector.onStreamRouterSpecChange(addedRouterSpecs, removedRouterSpecs, modifiedRouterSpecs, sds);
+        // switch cache
+        this.cachedSRS = newSRS;
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/PolicyState.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/PolicyState.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.model;
+
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.evaluator.CompositePolicyHandler;
+import org.apache.eagle.alert.engine.evaluator.PolicyStreamHandler;
+import org.apache.eagle.alert.engine.spark.accumulator.MapAccum;
+import org.apache.spark.Accumulator;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PolicyState implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(PolicyState.class);
+
+    private AtomicReference<Map<String, Map<String, PolicyDefinition>>> cachedPoliciesRef = new AtomicReference<>();
+
+    private Accumulator<Map<String, Map<String, PolicyDefinition>>> cachedPolicies;
+
+    private AtomicReference<Map<String, Map<String, PolicyDefinition>>> policyDefinitionRef = new AtomicReference<>();
+
+    private Accumulator<Map<String, Map<String, PolicyDefinition>>> policyDefinition;
+
+    private AtomicReference<Map<String, Map<String, CompositePolicyHandler>>> policyStreamHandlerRef = new AtomicReference<>();
+
+    private Accumulator<Map<String, Map<String, CompositePolicyHandler>>> policyStreamHandler;
+
+    public PolicyState(JavaStreamingContext jssc) {
+        Accumulator<Map<String, Map<String, PolicyDefinition>>> cachedPolicies = jssc.sparkContext().accumulator(new HashMap<>(), "policyAccum", new MapAccum());
+        Accumulator<Map<String, Map<String, PolicyDefinition>>> policyDefinition = jssc.sparkContext().accumulator(new HashMap<>(), "policyDefinitionAccum", new MapAccum());
+        Accumulator<Map<String, Map<String, CompositePolicyHandler>>> policyStreamHandler = jssc.sparkContext().accumulator(new HashMap<>(), "policyStreamHandlerAccum", new MapAccum());
+        this.cachedPolicies = cachedPolicies;
+        this.policyDefinition = policyDefinition;
+        this.policyStreamHandler = policyStreamHandler;
+    }
+
+    public PolicyState(Accumulator<Map<String, Map<String, PolicyDefinition>>> cachedPolicies, Accumulator<Map<String, Map<String, PolicyDefinition>>> policyDefinition,
+                       Accumulator<Map<String, Map<String, CompositePolicyHandler>>> policyStreamHandler) {
+        this.cachedPolicies = cachedPolicies;
+        this.policyDefinition = policyDefinition;
+        this.policyStreamHandler = policyStreamHandler;
+    }
+
+    public void recover() {
+        cachedPoliciesRef.set(cachedPolicies.value());
+        policyDefinitionRef.set(policyDefinition.value());
+        policyStreamHandlerRef.set(policyStreamHandler.value());
+        LOG.debug("---------cachedPoliciesRef----------" + cachedPoliciesRef.get());
+        LOG.debug("---------policyDefinitionRef----------" + policyDefinitionRef.get());
+        LOG.debug("---------policyStreamHandlerRef----------" + policyStreamHandlerRef.get());
+    }
+
+    public void store(String boltId, Map<String, PolicyDefinition> cachedPoliciesMap, Map<String, PolicyDefinition> newPolicyDefinition, Map<String, CompositePolicyHandler> newPolicyStreamHandler) {
+        Map<String, Map<String, PolicyDefinition>> cachedPolicy = new HashMap<>();
+        cachedPolicy.put(boltId, cachedPoliciesMap);
+        LOG.debug("---------store---cachedPoliciesMap----------" + cachedPoliciesMap);
+        cachedPolicies.add(cachedPolicy);
+
+        Map<String, Map<String, PolicyDefinition>> policyDefinitionMap = new HashMap<>();
+        policyDefinitionMap.put(boltId, newPolicyDefinition);
+        policyDefinition.add(policyDefinitionMap);
+
+        Map<String, Map<String, CompositePolicyHandler>> policyStreamHandlerMap = new HashMap<>();
+        policyStreamHandlerMap.put(boltId, newPolicyStreamHandler);
+        policyStreamHandler.add(policyStreamHandlerMap);
+
+    }
+
+    public Map<String, PolicyDefinition> getCachedPolicyByBoltId(String boltId) {
+        Map<String, Map<String, PolicyDefinition>> boltIdToPolicy = cachedPoliciesRef.get();
+        LOG.debug("---PolicyState----getPolicyByBoltId----------" + (boltIdToPolicy));
+        Map<String, PolicyDefinition> boltIdToPolicykMap = boltIdToPolicy.get(boltId);
+        if (boltIdToPolicykMap == null) {
+            boltIdToPolicykMap = new HashMap<>();
+        }
+        return boltIdToPolicykMap;
+    }
+
+    public Map<String, PolicyDefinition> getPolicyDefinitionByBoltId(String boltId) {
+        Map<String, Map<String, PolicyDefinition>> boltIdToPolicy = policyDefinitionRef.get();
+        LOG.debug("---PolicyState----getPolicyDefinitionByBoltId----------" + (boltIdToPolicy));
+        Map<String, PolicyDefinition> boltIdToPolicyMap = boltIdToPolicy.get(boltId);
+        if (boltIdToPolicyMap == null) {
+            boltIdToPolicyMap = new HashMap<>();
+        }
+        return boltIdToPolicyMap;
+    }
+
+    public Map<String, CompositePolicyHandler> getPolicyStreamHandlerByBoltId(String boltId) {
+        Map<String, Map<String, CompositePolicyHandler>> boltIdToPolicyStreamHandler = policyStreamHandlerRef.get();
+        LOG.debug("---PolicyState----getPolicyStreamHandlerByBoltId----------" + (boltIdToPolicyStreamHandler));
+        Map<String, CompositePolicyHandler> boltIdToPolicyStreamHandlerMap = boltIdToPolicyStreamHandler.get(boltId);
+        if (boltIdToPolicyStreamHandlerMap == null) {
+            boltIdToPolicyStreamHandlerMap = new HashMap<>();
+        }
+        return boltIdToPolicyStreamHandlerMap;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/PublishState.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/PublishState.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.model;
+
+import org.apache.eagle.alert.engine.coordinator.Publishment;
+
+import org.apache.eagle.alert.engine.spark.accumulator.MapAccum;
+import org.apache.spark.Accumulator;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PublishState implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(PublishState.class);
+    private AtomicReference<Map<String, Map<String, Publishment>>> cachedPublishmentsRef = new AtomicReference<>();
+
+    private Accumulator<Map<String, Map<String, Publishment>>> cachedPublishmentsAccum;
+
+    public PublishState(JavaStreamingContext jssc) {
+        Accumulator<Map<String, Map<String, Publishment>>> cachedPublishmentsAccum = jssc.sparkContext().accumulator(new HashMap<>(), "cachedPublishmentsAccum", new MapAccum());
+        this.cachedPublishmentsAccum = cachedPublishmentsAccum;
+    }
+
+    public void recover() {
+        cachedPublishmentsRef.set(cachedPublishmentsAccum.value());
+        LOG.debug("---------cachedPublishmentsRef----------" + cachedPublishmentsRef.get());
+    }
+
+    public void store(String streamId, Map<String, Publishment> cachedPublishments) {
+
+        if (!cachedPublishments.isEmpty()) {
+            Map<String, Map<String, Publishment>> newCachedPublishments = new HashMap<>();
+            newCachedPublishments.put(streamId, cachedPublishments);
+            cachedPublishmentsAccum.add(newCachedPublishments);
+        }
+
+    }
+
+    public Map<String, Publishment> getCachedPublishmentsByStreamId(String streamId) {
+        Map<String, Map<String, Publishment>> streamIdToCachedPublishments = cachedPublishmentsRef.get();
+        LOG.debug("---PublishState----getCachedPublishmentsByStreamId----------" + (streamIdToCachedPublishments));
+        Map<String, Publishment> cachedPublishments = streamIdToCachedPublishments.get(streamId);
+        if (cachedPublishments == null) {
+            cachedPublishments = new HashMap<>();
+        }
+        return cachedPublishments;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/RouteState.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/RouteState.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.model;
+
+import org.apache.eagle.alert.coordination.model.StreamRouterSpec;
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.engine.coordinator.StreamSortSpec;
+import org.apache.eagle.alert.engine.router.StreamRoutePartitioner;
+import org.apache.eagle.alert.engine.router.impl.SparkStreamRouterBoltOutputCollector;
+import org.apache.eagle.alert.engine.spark.accumulator.MapAccum;
+import org.apache.spark.Accumulator;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class RouteState implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RouteState.class);
+    private AtomicReference<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> routeSpecMapRef = new AtomicReference<>();
+    private AtomicReference<Map<Integer, Map<StreamPartition, List<StreamRoutePartitioner>>>> routePartitionerMapRef = new AtomicReference<>();
+    private AtomicReference<Map<Integer, Map<StreamPartition, StreamSortSpec>>> cachedSSSRef = new AtomicReference<>();
+    private AtomicReference<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> cachedSRSRef = new AtomicReference<>();
+
+    private Accumulator<Map<Integer, Map<StreamPartition, StreamSortSpec>>> cachedSSSAccm;
+    private Accumulator<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> cachedSRSAccm;
+    private Accumulator<Map<Integer, Map<StreamPartition, List<StreamRoutePartitioner>>>> routePartitionerAccum;
+    private Accumulator<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> routeSpecMapAccum;
+
+    public RouteState(JavaStreamingContext jssc) {
+        Accumulator<Map<Integer, Map<StreamPartition, List<StreamRoutePartitioner>>>> routePartitionerAccum = jssc.sparkContext().accumulator(new HashMap<>(), "routePartitionerAccum", new MapAccum());
+        this.routePartitionerAccum = routePartitionerAccum;
+        Accumulator<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> routeSpecMapAccum = jssc.sparkContext().accumulator(new HashMap<>(), "routeSpecAccum", new MapAccum());
+        this.routeSpecMapAccum = routeSpecMapAccum;
+        Accumulator<Map<Integer, Map<StreamPartition, StreamSortSpec>>> cachedSSSAccm = jssc.sparkContext().accumulator(new HashMap<>(), "cachedSSSAccm", new MapAccum());
+        this.cachedSSSAccm = cachedSSSAccm;
+        Accumulator<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> cachedSRSAccm = jssc.sparkContext().accumulator(new HashMap<>(), "cachedSRSAccm", new MapAccum());
+        this.cachedSRSAccm = cachedSRSAccm;
+
+    }
+
+    public RouteState(Accumulator<Map<Integer, Map<StreamPartition, List<StreamRoutePartitioner>>>> routePartitionerAccum,
+                      Accumulator<Map<Integer, Map<StreamPartition, StreamRouterSpec>>> routeSpecMapAccum) {
+        this.routePartitionerAccum = routePartitionerAccum;
+        this.routeSpecMapAccum = routeSpecMapAccum;
+    }
+
+    public void recover() {
+        routeSpecMapRef.set(routeSpecMapAccum.value());
+        routePartitionerMapRef.set(routePartitionerAccum.value());
+        cachedSSSRef.set(cachedSSSAccm.value());
+        cachedSRSRef.set(cachedSRSAccm.value());
+        LOG.debug("---------routeSpecMapRef----------" + routeSpecMapRef.get());
+        LOG.debug("---------routePartitionerMapRef----------" + routePartitionerMapRef.get());
+        LOG.debug("---------cachedSSSRef----------" + cachedSSSRef.get());
+        LOG.debug("---------cachedSRSRef----------" + cachedSRSRef.get());
+    }
+
+    public Map<StreamPartition, StreamRouterSpec> getRouteSpecMapByPartition(int partitionNum) {
+        Map<Integer, Map<StreamPartition, StreamRouterSpec>> partitionTorouteSpecMap = routeSpecMapRef.get();
+        LOG.debug("---RouteState----getRouteSpecMapByPartition----------" + (partitionTorouteSpecMap));
+        Map<StreamPartition, StreamRouterSpec> routeSpec = partitionTorouteSpecMap.get(partitionNum);
+        if (routeSpec == null) {
+            routeSpec = new HashMap<>();
+        }
+        return routeSpec;
+    }
+
+    public Map<StreamPartition, List<StreamRoutePartitioner>> getRoutePartitionerByPartition(int partitionNum) {
+
+        Map<Integer, Map<StreamPartition, List<StreamRoutePartitioner>>> partitionToroutePartitioner = routePartitionerMapRef.get();
+        LOG.debug("---RouteState----getRoutePartitionerByPartition----------" + (partitionToroutePartitioner));
+        Map<StreamPartition, List<StreamRoutePartitioner>> routePartitioner = partitionToroutePartitioner.get(partitionNum);
+        if (routePartitioner == null) {
+            routePartitioner = new HashMap<>();
+        }
+        return routePartitioner;
+    }
+
+    public Map<StreamPartition, StreamSortSpec> getCachedSSSMapByPartition(int partitionNum) {
+        Map<Integer, Map<StreamPartition, StreamSortSpec>> cachedSSSMap =  cachedSSSRef.get();
+        LOG.debug("---RouteState----getCachedSSSMapByPartition----------" + (cachedSSSMap));
+        Map<StreamPartition, StreamSortSpec> cachedSSS = cachedSSSMap.get(partitionNum);
+        if (cachedSSS == null) {
+            cachedSSS = new HashMap<>();
+        }
+        return cachedSSS;
+    }
+
+    public Map<StreamPartition, StreamRouterSpec> getCachedSRSMapByPartition(int partitionNum) {
+        Map<Integer, Map<StreamPartition, StreamRouterSpec>> cachedSRSMap =  cachedSRSRef.get();
+        LOG.debug("---RouteState----getCachedSRSMapByPartition----------" + (cachedSRSMap));
+        Map<StreamPartition, StreamRouterSpec> cachedSRS = cachedSRSMap.get(partitionNum);
+        if (cachedSRS == null) {
+            cachedSRS = new HashMap<>();
+        }
+        return cachedSRS;
+    }
+
+    public void store(SparkStreamRouterBoltOutputCollector routeCollector, Map<StreamPartition, StreamSortSpec> cachedSSS, Map<StreamPartition, StreamRouterSpec> cachedSRS, int partitionNum) {
+
+        Map<Integer, Map<StreamPartition, StreamRouterSpec>> newRouteSpecMap = new HashMap<>();
+        newRouteSpecMap.put(partitionNum, routeCollector.getRouteSpecMap());
+        routeSpecMapAccum.add(newRouteSpecMap);
+
+        Map<Integer, Map<StreamPartition, List<StreamRoutePartitioner>>> newRoutePartitionerMap = new HashMap<>();
+        newRoutePartitionerMap.put(partitionNum, routeCollector.getRoutePartitionerMap());
+        routePartitionerAccum.add(newRoutePartitionerMap);
+
+
+        Map<Integer, Map<StreamPartition, StreamSortSpec>> newCachedSSSMap = new HashMap<>();
+        newCachedSSSMap.put(partitionNum, cachedSSS);
+        cachedSSSAccm.add(newCachedSSSMap);
+
+        Map<Integer, Map<StreamPartition, StreamRouterSpec>> newCachedSRSMap = new HashMap<>();
+        newCachedSRSMap.put(partitionNum, cachedSRS);
+        cachedSRSAccm.add(newCachedSRSMap);
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/SiddhiState.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/SiddhiState.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.model;
+
+import org.apache.eagle.alert.engine.spark.accumulator.MapAccum;
+import org.apache.spark.Accumulator;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SiddhiState implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(SiddhiState.class);
+    private AtomicReference<Map<Integer, Map<String, byte[]>>> siddhiSnapshot = new AtomicReference<>();
+    private Accumulator<Map<Integer, Map<String, byte[]>>> siddhiSnapShotAccum;
+
+    public SiddhiState(JavaStreamingContext jssc) {
+        Accumulator<Map<Integer, Map<String, byte[]>>> siddhiSnapShotAccum = jssc.sparkContext().accumulator(new HashMap<>(), "siddhiSnapShotState", new MapAccum());
+        this.siddhiSnapShotAccum = siddhiSnapShotAccum;
+    }
+
+    public void recover() {
+        siddhiSnapshot.set(siddhiSnapShotAccum.value());
+        LOG.debug("---------siddhiSnapshot----------" + siddhiSnapshot.get());
+    }
+
+    public void store(byte[] snapShot, String boltId, int partitionNum) {
+        Map<Integer, Map<String, byte[]>> siddhiSnapShot = new HashMap<>();
+        Map<String, byte[]> boltIdToSnapShot = new HashMap<>();
+        boltIdToSnapShot.put(boltId, snapShot);
+        siddhiSnapShot.put(partitionNum, boltIdToSnapShot);
+        LOG.debug("---------store---siddhiSnapshot----------" + siddhiSnapShot);
+        siddhiSnapShotAccum.add(siddhiSnapShot);
+    }
+
+    public byte[] getSiddhiSnapShotByBoltIdAndPartitionNum(String boltId, int partitionNum) {
+        Map<Integer, Map<String, byte[]>> partitionToSnapShot = siddhiSnapshot.get();
+        LOG.debug("---SiddhiState----getSiddhiSnapShotByPartition----------" + (partitionToSnapShot));
+        Map<String, byte[]> boltIdToSnapShot = partitionToSnapShot.get(partitionNum);
+        byte[] siddhiSnapshot = null;
+        if (boltIdToSnapShot != null) {
+            siddhiSnapshot = boltIdToSnapShot.get(boltId);
+        }
+        return siddhiSnapshot;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/WindowState.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/model/WindowState.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.model;
+
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.engine.router.StreamSortHandler;
+import org.apache.eagle.alert.engine.router.impl.StreamRouterImpl;
+import org.apache.eagle.alert.engine.sorter.StreamTimeClock;
+import org.apache.eagle.alert.engine.sorter.StreamTimeClockListener;
+import org.apache.eagle.alert.engine.spark.accumulator.MapAccum;
+import org.apache.spark.Accumulator;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class WindowState implements Serializable {
+
+    private AtomicReference<Map<Integer, Map<String, StreamTimeClock>>> streamTimeClockRef = new AtomicReference<>();
+    private AtomicReference<Map<Integer, Map<StreamTimeClockListener, String>>> streamWindowRef = new AtomicReference<>();
+    private AtomicReference<Map<Integer, Map<StreamPartition, StreamSortHandler>>> streamSortHandlersRef = new AtomicReference<>();
+    private Accumulator<Map<Integer, Map<String, StreamTimeClock>>> streamIdClockAccum;
+    private Accumulator<Map<Integer, Map<StreamTimeClockListener, String>>> streamWindowAccum;
+    private Accumulator<Map<Integer, Map<StreamPartition, StreamSortHandler>>> streamSortHandlersAccum;
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowState.class);
+
+    public WindowState(JavaStreamingContext jssc) {
+        Accumulator<Map<Integer, Map<String, StreamTimeClock>>> streamIdClockAccum = jssc.sparkContext().accumulator(new HashMap<>(), "streamIdClock", new MapAccum());
+        Accumulator<Map<Integer, Map<StreamTimeClockListener, String>>> streamWindowAccum = jssc.sparkContext().accumulator(new HashMap<>(), "streamWindow", new MapAccum());
+        Accumulator<Map<Integer, Map<StreamPartition, StreamSortHandler>>> streamSortHandlersAccum = jssc.sparkContext().accumulator(new HashMap<>(), "streamSortHandlers", new MapAccum());
+        this.streamIdClockAccum = streamIdClockAccum;
+        this.streamWindowAccum = streamWindowAccum;
+        this.streamSortHandlersAccum = streamSortHandlersAccum;
+    }
+
+    public WindowState(Accumulator<Map<Integer, Map<String, StreamTimeClock>>> streamIdClockAccum, Accumulator<Map<Integer, Map<StreamTimeClockListener, String>>> streamWindowAccum,
+                       Accumulator<Map<Integer, Map<StreamPartition, StreamSortHandler>>> streamSortHandlersAccum) {
+        this.streamIdClockAccum = streamIdClockAccum;
+        this.streamWindowAccum = streamWindowAccum;
+        this.streamSortHandlersAccum = streamSortHandlersAccum;
+    }
+
+    public Map<Integer, Map<String, StreamTimeClock>> getStreamTimeClock() {
+        return streamTimeClockRef.get();
+    }
+
+    public Map<Integer, Map<StreamTimeClockListener, String>> getStreamWindows() {
+        return streamWindowRef.get();
+    }
+
+    public void recover() {
+        streamTimeClockRef.set(streamIdClockAccum.value());
+        streamWindowRef.set(streamWindowAccum.value());
+        streamSortHandlersRef.set(streamSortHandlersAccum.value());
+
+        LOG.debug("---------streamTimeClock----------" + streamTimeClockRef.get());
+        LOG.debug("---------streamWindowRef----------" + streamWindowRef.get());
+        LOG.debug("---------streamSortHandlersRef----------" + streamSortHandlersRef.get());
+    }
+
+    public void store(StreamRouterImpl router, int partitionNum) {
+
+        //store clock
+        Map<Integer, Map<String, StreamTimeClock>> newStreamTimeClock = new HashMap<>();
+        newStreamTimeClock.put(partitionNum, router.getStreamTimeClock());
+        streamIdClockAccum.add(newStreamTimeClock);
+        //store window
+        Map<Integer, Map<StreamTimeClockListener, String>> newStreamWindow = new HashMap<>();
+        newStreamWindow.put(partitionNum, router.getAllListenerStreamIdMap());
+        streamWindowAccum.add(newStreamWindow);
+        //store sort handler
+        Map<Integer, Map<StreamPartition, StreamSortHandler>> newstreamSortHandler = new HashMap<>();
+        newstreamSortHandler.put(partitionNum, router.getAllStreamSortHandlerMap());
+        streamSortHandlersAccum.add(newstreamSortHandler);
+    }
+
+    public Map<String, StreamTimeClock> getStreamTimeClockByPartition(int partitionNum) {
+        Map<Integer, Map<String, StreamTimeClock>> partitionToStreamClock = getStreamTimeClock();
+        LOG.debug("---StreamRouteBoltFunction----getStreamTimeClockByPartition----------" + (partitionToStreamClock));
+        Map<String, StreamTimeClock> streamTimeClockMap = partitionToStreamClock.get(partitionNum);
+        if (streamTimeClockMap == null) {
+            streamTimeClockMap = new HashMap<>();
+        }
+        return streamTimeClockMap;
+    }
+
+    public Map<StreamTimeClockListener, String> getStreamWindowsByPartition(int partitionNum) {
+
+        Map<Integer, Map<StreamTimeClockListener, String>> partitionToStreamWindow = getStreamWindows();
+        LOG.debug("---StreamRouteBoltFunction----getStreamWindowsByPartition----------" + (partitionToStreamWindow));
+        Map<StreamTimeClockListener, String> streamWindowMap = partitionToStreamWindow.get(partitionNum);
+        if (streamWindowMap == null) {
+            streamWindowMap = new HashMap<>();
+        }
+        return streamWindowMap;
+    }
+
+    public Map<StreamPartition, StreamSortHandler> getStreamSortHandlerByPartition(int partitionNum) {
+        Map<Integer, Map<StreamPartition, StreamSortHandler>> partitionToStreamSortHandler = streamSortHandlersRef.get();
+        LOG.debug("---StreamRouteBoltFunction----streamSortHandlerMap----------" + (partitionToStreamSortHandler));
+        Map<StreamPartition, StreamSortHandler> streamSortHandlerMap = partitionToStreamSortHandler.get(partitionNum);
+        if (streamSortHandlerMap == null) {
+            streamSortHandlerMap = new HashMap<>();
+        }
+        return streamSortHandlerMap;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/partition/StreamRoutePartitioner.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/spark/partition/StreamRoutePartitioner.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.spark.partition;
+
+import org.apache.spark.Partitioner;
+
+public class StreamRoutePartitioner extends Partitioner {
+    private int numParts;
+
+    public StreamRoutePartitioner(int numParts) {
+        this.numParts = numParts;
+    }
+
+    @Override
+    public int numPartitions() {
+        return numParts;
+    }
+
+    @Override
+    public int getPartition(Object routeIndex) {
+        return (Integer) routeIndex;
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/Constants.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/Constants.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.utils;
+
+public class Constants {
+    public static final int UNKNOW_PARTITION = -1;
+    public static final String UNKNOW_STREAMID = "xx";
+    public static final String ALERTBOLTNAME_PREFIX = "alertBolt";
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/Constants.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/Constants.java
@@ -21,4 +21,5 @@ public class Constants {
     public static final int UNKNOW_PARTITION = -1;
     public static final String UNKNOW_STREAMID = "xx";
     public static final String ALERTBOLTNAME_PREFIX = "alertBolt";
+    public static final String TOPOLOGY_ID = "topologyId";
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/SpecUtils.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/SpecUtils.java
@@ -18,29 +18,193 @@
 package org.apache.eagle.alert.engine.utils;
 
 import com.typesafe.config.Config;
-import org.apache.eagle.alert.coordination.model.SpoutSpec;
-import org.apache.eagle.alert.service.SpecMetadataServiceClientImpl;
+import org.apache.eagle.alert.coordination.model.*;
+import org.apache.eagle.alert.coordination.model.internal.StreamGroup;
+import org.apache.eagle.alert.coordination.model.internal.StreamWorkSlotQueue;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.coordinator.Publishment;
+import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
+import org.apache.eagle.alert.engine.coordinator.StreamPartition;
+import org.apache.eagle.alert.service.IMetadataServiceClient;
+import org.apache.eagle.alert.service.MetadataServiceClientImpl;
 
-import java.util.Collections;
-import java.util.Set;
+import java.util.*;
 
 public class SpecUtils {
-    public static Set<String> getTopicsByClient(SpecMetadataServiceClientImpl client) {
-        if (client == null) {
-            return Collections.emptySet();
-        }
-        return client.getSpoutSpec().getKafka2TupleMetadataMap().keySet();
-    }
 
-    public static Set<String> getTopicsByConfig(Config config) {
-        SpecMetadataServiceClientImpl client = new SpecMetadataServiceClientImpl(config);
-        return SpecUtils.getTopicsByClient(client);
-    }
 
     public static Set<String> getTopicsBySpoutSpec(SpoutSpec spoutSpec) {
         if (spoutSpec == null) {
             return Collections.emptySet();
         }
         return spoutSpec.getKafka2TupleMetadataMap().keySet();
+    }
+
+    public static Set<String> getTopicsByConfig(Config config) {
+        IMetadataServiceClient client = new MetadataServiceClientImpl(config);
+        List<Kafka2TupleMetadata> kafka2TupleMetadata = client.listDataSources();
+        Set<String> topics = new HashSet<>();
+        for (Kafka2TupleMetadata eachKafka2TupleMetadata : kafka2TupleMetadata) {
+            topics.add(eachKafka2TupleMetadata.getTopic());
+        }
+        return topics;
+    }
+
+    public static PublishSpec generatePublishSpec(IMetadataServiceClient mtadataServiceClient) {
+        PublishSpec publishSpec = new PublishSpec(Constants.TOPOLOGY_ID, "alertPublishBolt");
+        Map<String, List<Publishment>> policyToPub = new HashMap<>();
+        List<Publishment> publishments = mtadataServiceClient.listPublishment();
+        for (Publishment pub : publishments) {
+            for (String policyId : pub.getPolicyIds()) {
+                List<Publishment> policyPubs = policyToPub.get(policyId);
+                if (policyPubs == null) {
+                    policyPubs = new ArrayList<>();
+                    policyToPub.put(policyId, policyPubs);
+                }
+                policyPubs.add(pub);
+            }
+        }
+        List<PolicyDefinition> policyDefinitions = mtadataServiceClient.listPolicies();
+        for (PolicyDefinition eachPolicyDefinition : policyDefinitions) {
+            String policyId = eachPolicyDefinition.getName();
+            if (policyToPub.containsKey(policyId)) {
+                for (Publishment pub : policyToPub.get(policyId)) {
+                    publishSpec.addPublishment(pub);
+                }
+            }
+        }
+
+        return publishSpec;
+    }
+
+    public static Map<String, StreamDefinition> generateSds(IMetadataServiceClient mtadataServiceClient) {
+        Map<String, StreamDefinition> streamSchemaMap = new HashMap<>();
+        List<StreamDefinition> streamDefinitions = mtadataServiceClient.listStreams();
+        for (StreamDefinition eachStreamDefinition : streamDefinitions) {
+            streamSchemaMap.put(eachStreamDefinition.getStreamId(), eachStreamDefinition);
+        }
+        return streamSchemaMap;
+    }
+
+    public static AlertBoltSpec generateAlertBoltSpec(IMetadataServiceClient mtadataServiceClient, int numOfAlertBolts) {
+        AlertBoltSpec alertSpec = new AlertBoltSpec(Constants.TOPOLOGY_ID);
+        Map<String, List<PolicyDefinition>> boltPoliciesMap = new HashMap<>();
+        List<PolicyDefinition> policyDefinitions = mtadataServiceClient.listPolicies();
+        List<String> alertBolts = generateAlertBolt(numOfAlertBolts);
+        for (String alertBolt : alertBolts) {
+            boltPoliciesMap.put(alertBolt, policyDefinitions);
+        }
+        alertSpec.setBoltPoliciesMap(boltPoliciesMap);
+        return alertSpec;
+    }
+
+
+    public static RouterSpec generateRouterSpec(IMetadataServiceClient mtadataServiceClient, int numOfAlertBolts) {
+        List<StreamWorkSlotQueue> queues = new ArrayList<>();
+        List<WorkSlot> workingSlots = new LinkedList<>();
+        List<String> alertBolts = generateAlertBolt(numOfAlertBolts);
+        for (String alertBolt : alertBolts) {
+            workingSlots.add(new WorkSlot(Constants.TOPOLOGY_ID, alertBolt));
+        }
+        StreamWorkSlotQueue streamWorkSlotQueue = new StreamWorkSlotQueue(new StreamGroup(), false, new HashMap<>(), workingSlots);
+        queues.add(streamWorkSlotQueue);
+        RouterSpec routerSpec = new RouterSpec(Constants.TOPOLOGY_ID);
+        List<PolicyDefinition> policyDefinitions = mtadataServiceClient.listPolicies();
+        for (PolicyDefinition eachPolicyDefinition : policyDefinitions) {
+            List<StreamPartition> streamPartitions = eachPolicyDefinition.getPartitionSpec();
+            for (StreamPartition streamPartition : streamPartitions) {
+                StreamRouterSpec routeSpec = new StreamRouterSpec();
+                routeSpec.setPartition(streamPartition);
+                routeSpec.setStreamId(streamPartition.getStreamId());
+                for (StreamWorkSlotQueue sq : queues) {
+                    PolicyWorkerQueue queue = new PolicyWorkerQueue();
+                    queue.setWorkers(sq.getWorkingSlots());
+                    queue.setPartition(streamPartition);
+                    routeSpec.addQueue(queue);
+                }
+                routerSpec.addRouterSpec(routeSpec);
+            }
+
+        }
+
+
+        return routerSpec;
+    }
+
+    public static SpoutSpec generateSpout(IMetadataServiceClient mtadataServiceClient, int numOfAlertBolts) {
+        // streamId -> StreamDefinition
+        Map<String, StreamDefinition> streamSchemaMap = new HashMap<>();
+        List<StreamDefinition> streamDefinitions = mtadataServiceClient.listStreams();
+        for (StreamDefinition eachStreamDefinition : streamDefinitions) {
+            streamSchemaMap.put(eachStreamDefinition.getStreamId(), eachStreamDefinition);
+        }
+        //generate datasource -> Kafka2TupleMetadata
+        Map<String, Kafka2TupleMetadata> datasourceTupleMetadataMap = new HashMap<>();
+        // generate topic -> Kafka2TupleMetadata
+        Map<String, Kafka2TupleMetadata> kafka2TupleMetadataMap = new HashMap<>();
+        // generate topic -> Tuple2StreamMetadata
+        Map<String, Tuple2StreamMetadata> tuple2StreamMetadataMap = new HashMap<>();
+        // generate topicId -> StreamRepartitionMetadata
+        Map<String, List<StreamRepartitionMetadata>> streamRepartitionMetadataMap = new HashMap<>();
+        List<Kafka2TupleMetadata> kafka2TupleMetadata = mtadataServiceClient.listDataSources();
+        for (Kafka2TupleMetadata eachKafka2TupleMetadata : kafka2TupleMetadata) {
+            String topic = eachKafka2TupleMetadata.getTopic();
+            datasourceTupleMetadataMap.put(eachKafka2TupleMetadata.getName(), eachKafka2TupleMetadata);
+            kafka2TupleMetadataMap.put(topic, eachKafka2TupleMetadata);
+            tuple2StreamMetadataMap.put(topic, eachKafka2TupleMetadata.getCodec());
+        }
+        List<PolicyDefinition> policyDefinitions = mtadataServiceClient.listPolicies();
+        for (PolicyDefinition eachPolicyDefinition : policyDefinitions) {
+            for (StreamPartition policyStreamPartition : eachPolicyDefinition.getPartitionSpec()) {
+                String stream = policyStreamPartition.getStreamId();
+                StreamDefinition schema = streamSchemaMap.get(stream);
+                String topic = datasourceTupleMetadataMap.get(schema.getDataSource()).getTopic();
+                // add stream name to tuple metadata
+                if (tuple2StreamMetadataMap.containsKey(topic)) {
+                    Tuple2StreamMetadata tupleMetadata = tuple2StreamMetadataMap.get(topic);
+                    tupleMetadata.getActiveStreamNames().add(stream);
+                }
+                // grouping strategy
+                StreamRepartitionStrategy gs = new StreamRepartitionStrategy();
+                gs.partition = policyStreamPartition;
+                gs.numTotalParticipatingRouterBolts = numOfAlertBolts;
+                // add to map
+                addGroupingStrategy(streamRepartitionMetadataMap, stream, schema, topic, schema.getDataSource(), gs);
+            }
+        }
+        return new SpoutSpec(Constants.TOPOLOGY_ID, streamRepartitionMetadataMap, tuple2StreamMetadataMap, kafka2TupleMetadataMap);
+    }
+
+    private static void addGroupingStrategy(Map<String, List<StreamRepartitionMetadata>> streamsMap, String stream,
+                                            StreamDefinition schema, String topicName, String datasourceName, StreamRepartitionStrategy gs) {
+        List<StreamRepartitionMetadata> dsStreamMeta;
+        if (streamsMap.containsKey(topicName)) {
+            dsStreamMeta = streamsMap.get(topicName);
+        } else {
+            dsStreamMeta = new ArrayList<>();
+            streamsMap.put(topicName, dsStreamMeta);
+        }
+        StreamRepartitionMetadata targetSm = null;
+        for (StreamRepartitionMetadata sm : dsStreamMeta) {
+            if (stream.equalsIgnoreCase(sm.getStreamId())) {
+                targetSm = sm;
+                break;
+            }
+        }
+        if (targetSm == null) {
+            targetSm = new StreamRepartitionMetadata(topicName, schema.getStreamId());
+            dsStreamMeta.add(targetSm);
+        }
+        if (!targetSm.groupingStrategies.contains(gs)) {
+            targetSm.addGroupStrategy(gs);
+        }
+    }
+
+    private static List<String> generateAlertBolt(int numOfAlertBolts) {
+        List<String> alertBolts = new ArrayList<>(numOfAlertBolts);
+        for (int j = 0; j < numOfAlertBolts; j++) {
+            alertBolts.add(Constants.ALERTBOLTNAME_PREFIX + j);
+        }
+        return alertBolts;
     }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/SpecUtils.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/java/org/apache/eagle/alert/engine/utils/SpecUtils.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.alert.engine.utils;
+
+import com.typesafe.config.Config;
+import org.apache.eagle.alert.coordination.model.SpoutSpec;
+import org.apache.eagle.alert.service.SpecMetadataServiceClientImpl;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class SpecUtils {
+    public static Set<String> getTopicsByClient(SpecMetadataServiceClientImpl client) {
+        if (client == null) {
+            return Collections.emptySet();
+        }
+        return client.getSpoutSpec().getKafka2TupleMetadataMap().keySet();
+    }
+
+    public static Set<String> getTopicsByConfig(Config config) {
+        SpecMetadataServiceClientImpl client = new SpecMetadataServiceClientImpl(config);
+        return SpecUtils.getTopicsByClient(client);
+    }
+
+    public static Set<String> getTopicsBySpoutSpec(SpoutSpec spoutSpec) {
+        if (spoutSpec == null) {
+            return Collections.emptySet();
+        }
+        return spoutSpec.getKafka2TupleMetadataMap().keySet();
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/scala/org/apache/spark/streaming/kafka/DynamicTopicKafkaInputDStream.scala
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/scala/org/apache/spark/streaming/kafka/DynamicTopicKafkaInputDStream.scala
@@ -1,0 +1,238 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+package org.apache.spark.streaming.kafka
+
+import kafka.common.TopicAndPartition
+import kafka.message.MessageAndMetadata
+import kafka.serializer.Decoder
+import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
+import org.apache.spark.streaming.dstream._
+import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
+import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
+import org.apache.spark.streaming.{StreamingContext, Time}
+
+import scala.annotation.tailrec
+import scala.collection.immutable.Map
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+/**
+  * NOTE!!!!! This class copy/paste some code from org.apache.spark.streaming.kafka.DirectKafkaInputDStream to make
+  * sure it can support dynamic add/delete topic without requiring restart of the streaming context.
+  *
+  * A stream of {@link org.apache.spark.streaming.kafka.KafkaRDD} where
+  * each given Kafka topic/partition corresponds to an RDD partition.
+  * The spark configuration spark.streaming.kafka.maxRatePerPartition gives the maximum number
+  * of messages
+  * per second that each '''partition''' will accept.
+  * Starting offsets are specified in advance,
+  * and this DStream is not responsible for committing offsets,
+  * so that you can control exactly-once semantics.
+  * For an easy interface to Kafka-managed offsets,
+  * see {@link org.apache.spark.streaming.kafka.KafkaCluster}
+  *
+  * @param kafkaParams    Kafka <a href="http://kafka.apache.org/documentation.html#configuration">
+  *                       configuration parameters</a>.
+  *                       Requires "metadata.broker.list" or "bootstrap.servers" to be set with Kafka broker(s),
+  *                       NOT zookeeper servers, specified in host1:port1,host2:port2 form.
+  * @param fromOffsets    per-topic/partition Kafka offsets defining the (inclusive)
+  *                       starting point of the stream
+  * @param topicAndPartitionHandler Chang Map[TopicAndPartition, Long] dynamically to
+  *                                 support add/remove topic without restart
+  * @param messageHandler function for translating each message into the desired type
+  */
+private[streaming]
+class DynamicTopicKafkaInputDStream[
+K: ClassTag,
+V: ClassTag,
+U <: Decoder[K] : ClassTag,
+T <: Decoder[V] : ClassTag,
+R: ClassTag](
+              _ssc: StreamingContext,
+              val kafkaParams: Map[String, String],
+              val fromOffsets: Map[TopicAndPartition, Long],
+              topicAndPartitionHandler: Map[TopicAndPartition, Long] => Map[TopicAndPartition, Long],
+              messageHandler: MessageAndMetadata[K, V] => R
+            ) extends InputDStream[R](_ssc) with Logging {
+  val maxRetries = context.sparkContext.getConf.getInt(
+    "spark.streaming.kafka.maxRetries", 1)
+
+  // Keep this consistent with how other streams are named (e.g. "Flume polling stream [2]")
+  private[streaming] override def name: String = s"Kafka direct stream [$id]"
+
+  protected[streaming] override val checkpointData =
+    new DirectKafkaInputDStreamCheckpointData
+
+
+  /**
+    * Asynchronously maintains & sends new rate limits to the receiver through the receiver tracker.
+    */
+  override protected[streaming] val rateController: Option[RateController] = {
+    if (RateController.isBackPressureEnabled(ssc.conf)) {
+      Some(new DirectKafkaRateController(id,
+        RateEstimator.create(ssc.conf, context.graph.batchDuration)))
+    } else {
+      None
+    }
+  }
+
+  protected val kc = new KafkaCluster(kafkaParams)
+
+  private val maxRateLimitPerPartition: Int = context.sparkContext.getConf.getInt(
+    "spark.streaming.kafka.maxRatePerPartition", 0)
+
+  protected[streaming] def maxMessagesPerPartition(
+                                                    offsets: Map[TopicAndPartition, Long]): Option[Map[TopicAndPartition, Long]] = {
+    val estimatedRateLimit = rateController.map(_.getLatestRate().toInt)
+
+    // calculate a per-partition rate limit based on current lag
+    val effectiveRateLimitPerPartition = estimatedRateLimit.filter(_ > 0) match {
+      case Some(rate) =>
+        val lagPerPartition = offsets.map { case (tp, offset) =>
+          tp -> Math.max(offset - currentOffsets(tp), 0)
+        }
+        val totalLag = lagPerPartition.values.sum
+
+        lagPerPartition.map { case (tp, lag) =>
+          val backpressureRate = Math.round(lag / totalLag.toFloat * rate)
+          tp -> (if (maxRateLimitPerPartition > 0) {
+            Math.min(backpressureRate, maxRateLimitPerPartition)
+          } else backpressureRate)
+        }
+      case None => offsets.map { case (tp, offset) => tp -> maxRateLimitPerPartition }
+    }
+
+    if (effectiveRateLimitPerPartition.values.sum > 0) {
+      val secsPerBatch = context.graph.batchDuration.milliseconds.toDouble / 1000
+      Some(effectiveRateLimitPerPartition.map {
+        case (tp, limit) => tp -> (secsPerBatch * limit).toLong
+      })
+    } else {
+      None
+    }
+  }
+
+  protected var currentOffsets = fromOffsets
+
+  @tailrec
+  protected final def latestLeaderOffsets(retries: Int): Map[TopicAndPartition, LeaderOffset] = {
+    val o = kc.getLatestLeaderOffsets(currentOffsets.keySet)
+    // Either.fold would confuse @tailrec, do it manually
+    if (o.isLeft) {
+      val err = o.left.get.toString
+      if (retries <= 0) {
+        throw new SparkException(err)
+      } else {
+        log.error(err)
+        Thread.sleep(kc.config.refreshLeaderBackoffMs)
+        latestLeaderOffsets(retries - 1)
+      }
+    } else {
+      o.right.get
+    }
+  }
+
+  // limits the maximum number of messages per partition
+  protected def clamp(
+                       leaderOffsets: Map[TopicAndPartition, LeaderOffset]): Map[TopicAndPartition, LeaderOffset] = {
+    val offsets = leaderOffsets.mapValues(lo => lo.offset)
+
+    maxMessagesPerPartition(offsets).map { mmp =>
+      mmp.map { case (tp, messages) =>
+        val lo = leaderOffsets(tp)
+        tp -> lo.copy(offset = Math.min(currentOffsets(tp) + messages, lo.offset))
+      }
+    }.getOrElse(leaderOffsets)
+  }
+
+  override def compute(validTime: Time): Option[KafkaRDD[K, V, U, T, R]] = {
+    currentOffsets = topicAndPartitionHandler(currentOffsets)
+    val untilOffsets = clamp(latestLeaderOffsets(maxRetries))
+    val rdd = KafkaRDD[K, V, U, T, R](
+      context.sparkContext, kafkaParams, currentOffsets, untilOffsets, messageHandler)
+
+    // Report the record number and metadata of this batch interval to InputInfoTracker.
+    val offsetRanges = currentOffsets.map { case (tp, fo) =>
+      val uo = untilOffsets(tp)
+      OffsetRange(tp.topic, tp.partition, fo, uo.offset)
+    }
+    val description = offsetRanges.filter { offsetRange =>
+      // Don't display empty ranges.
+      offsetRange.fromOffset != offsetRange.untilOffset
+    }.map { offsetRange =>
+      s"topic: ${offsetRange.topic}\tpartition: ${offsetRange.partition}\t" +
+        s"offsets: ${offsetRange.fromOffset} to ${offsetRange.untilOffset}"
+    }.mkString("\n")
+    // Copy offsetRanges to immutable.List to prevent from being modified by the user
+    val metadata = Map(
+      "offsets" -> offsetRanges.toList,
+      StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
+    val inputInfo = StreamInputInfo(id, rdd.count, metadata)
+    ssc.scheduler.inputInfoTracker.reportInfo(validTime, inputInfo)
+
+    currentOffsets = untilOffsets.map(kv => kv._1 -> kv._2.offset)
+    Some(rdd)
+  }
+
+  override def start(): Unit = {
+  }
+
+  def stop(): Unit = {
+  }
+
+  private[streaming]
+  class DirectKafkaInputDStreamCheckpointData extends DStreamCheckpointData(this) {
+    def batchForTime: mutable.HashMap[Time, Array[(String, Int, Long, Long)]] = {
+      data.asInstanceOf[mutable.HashMap[Time, Array[OffsetRange.OffsetRangeTuple]]]
+    }
+
+    override def update(time: Time) {
+      batchForTime.clear()
+      generatedRDDs.foreach { kv =>
+        val a = kv._2.asInstanceOf[KafkaRDD[K, V, U, T, R]].offsetRanges.map(_.toTuple).toArray
+        batchForTime += kv._1 -> a
+      }
+    }
+
+    override def cleanup(time: Time) {}
+
+    override def restore() {
+      // this is assuming that the topics don't change during execution, which is true currently
+      val topics = currentOffsets.keySet
+      val leaders = KafkaCluster.checkErrors(kc.findLeaders(topics))
+
+      batchForTime.toSeq.sortBy(_._1)(Time.ordering).foreach { case (t, b) =>
+        logInfo(s"Restoring KafkaRDD for time $t ${b.mkString("[", ", ", "]")}")
+        generatedRDDs += t -> new KafkaRDD[K, V, U, T, R](
+          context.sparkContext, kafkaParams, b.map(OffsetRange(_)), leaders, messageHandler)
+      }
+    }
+  }
+
+  /**
+    * A RateController to retrieve the rate from RateEstimator.
+    */
+  private[streaming] class DirectKafkaRateController(id: Int, estimator: RateEstimator)
+    extends RateController(id, estimator) {
+    override def publish(rate: Long): Unit = ()
+  }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/scala/org/apache/spark/streaming/kafka/EagleKafkaUtils.scala
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/main/scala/org/apache/spark/streaming/kafka/EagleKafkaUtils.scala
@@ -1,0 +1,257 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+package org.apache.spark.streaming.kafka
+
+import java.lang.{Integer => JInt, Long => JLong}
+import java.util.concurrent.TimeUnit
+import java.util.{List => JList, Map => JMap, Set => JSet}
+
+import kafka.admin.AdminUtils
+import kafka.common.TopicAndPartition
+import kafka.message.MessageAndMetadata
+import kafka.serializer.Decoder
+import org.I0Itec.zkclient.ZkClient
+import org.apache.spark.api.java.function.{Function => JFunction}
+import org.apache.spark.internal.Logging
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.api.java._
+import org.apache.spark.streaming.dstream.InputDStream
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.{Map, Set}
+import scala.reflect.ClassTag
+
+object EagleKafkaUtils extends Logging {
+  private val ZK_TIMEOUT_MSEC: Int = TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS).toInt
+
+  /**
+    * Create an input stream that directly pulls messages from Kafka Brokers
+    * without using any receiver. This stream can guarantee that each message
+    * from Kafka is included in transformations exactly once (see points below).
+    *
+    * Points to note:
+    * - No receivers: This stream does not use any receiver. It directly queries Kafka
+    * - Offsets: This does not use Zookeeper to store offsets. The consumed offsets are tracked
+    * by the stream itself. For interoperability with Kafka monitoring tools that depend on
+    * Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application.
+    * You can access the offsets used in each batch from the generated RDDs (see
+    * [[org.apache.spark.streaming.kafka.HasOffsetRanges]]).
+    * - Failure Recovery: To recover from driver failures, you have to enable checkpointing
+    * in the [[StreamingContext]]. The information on consumed offset can be
+    * recovered from the checkpoint. See the programming guide for details (constraints, etc.).
+    * - End-to-end semantics: This stream ensures that every records is effectively received and
+    * transformed exactly once, but gives no guarantees on whether the transformed data are
+    * outputted exactly once. For end-to-end exactly-once semantics, you have to either ensure
+    * that the output operation is idempotent, or use transactions to output records atomically.
+    * See the programming guide for more details.
+    *
+    * @param ssc                      StreamingContext object
+    * @param kafkaParams              Kafka <a href="http://kafka.apache.org/documentation.html#configuration">
+    *                                 configuration parameters</a>. Requires "metadata.broker.list" or "bootstrap.servers"
+    *                                 to be set with Kafka broker(s) (NOT zookeeper servers) specified in
+    *                                 host1:port1,host2:port2 form.
+    * @param fromOffsets              Per-topic/partition Kafka offsets defining the (inclusive)
+    *                                 starting point of the stream
+    * @param topicAndPartitionHandler Chang Map[TopicAndPartition, Long] dynamically to
+    *                                 support add/remove topic without restart
+    * @param messageHandler           Function for translating each message and metadata into the desired type
+    * @tparam K  type of Kafka message key
+    * @tparam V  type of Kafka message value
+    * @tparam KD type of Kafka message key decoder
+    * @tparam VD type of Kafka message value decoder
+    * @tparam R  type returned by messageHandler
+    * @return DStream of R
+    */
+  def createDirectStreamWithHandler[
+  K: ClassTag,
+  V: ClassTag,
+  KD <: Decoder[K] : ClassTag,
+  VD <: Decoder[V] : ClassTag,
+  R: ClassTag](
+                ssc: StreamingContext,
+                kafkaParams: Map[String, String],
+                fromOffsets: Map[TopicAndPartition, Long],
+                topicAndPartitionHandler: Map[TopicAndPartition, Long] => Map[TopicAndPartition, Long],
+                messageHandler: MessageAndMetadata[K, V] => R
+              ): InputDStream[R] = {
+    val cleanedHandler = ssc.sc.clean(messageHandler)
+    val cleanedTopicAndPartitionHandler = ssc.sc.clean(topicAndPartitionHandler)
+    new DynamicTopicKafkaInputDStream[K, V, KD, VD, R](
+      ssc, kafkaParams, fromOffsets, cleanedTopicAndPartitionHandler, cleanedHandler)
+  }
+
+
+  /**
+    * Create an input stream that directly pulls messages from Kafka Brokers
+    * without using any receiver. This stream can guarantee that each message
+    * from Kafka is included in transformations exactly once (see points below).
+    *
+    * Points to note:
+    * - No receivers: This stream does not use any receiver. It directly queries Kafka
+    * - Offsets: This does not use Zookeeper to store offsets. The consumed offsets are tracked
+    * by the stream itself. For interoperability with Kafka monitoring tools that depend on
+    * Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application.
+    * You can access the offsets used in each batch from the generated RDDs (see
+    * [[org.apache.spark.streaming.kafka.HasOffsetRanges]]).
+    * - Failure Recovery: To recover from driver failures, you have to enable checkpointing
+    * in the [[StreamingContext]]. The information on consumed offset can be
+    * recovered from the checkpoint. See the programming guide for details (constraints, etc.).
+    * - End-to-end semantics: This stream ensures that every records is effectively received and
+    * transformed exactly once, but gives no guarantees on whether the transformed data are
+    * outputted exactly once. For end-to-end exactly-once semantics, you have to either ensure
+    * that the output operation is idempotent, or use transactions to output records atomically.
+    * See the programming guide for more details.
+    *
+    * @param jssc                     JavaStreamingContext object
+    * @param keyClass                 Class of the keys in the Kafka records
+    * @param valueClass               Class of the values in the Kafka records
+    * @param keyDecoderClass          Class of the key decoder
+    * @param valueDecoderClass        Class of the value decoder
+    * @param recordClass              Class of the records in DStream
+    * @param kafkaParams              Kafka <a href="http://kafka.apache.org/documentation.html#configuration">
+    *                                 configuration parameters</a>. Requires "metadata.broker.list" or "bootstrap.servers"
+    *                                 to be set with Kafka broker(s) (NOT zookeeper servers), specified in
+    *                                 host1:port1,host2:port2 form.
+    * @param fromOffsets              Per-topic/partition Kafka offsets defining the (inclusive)
+    *                                 starting point of the stream
+    * @param topicAndPartitionHandler Chang Map[TopicAndPartition, Long] dynamically to
+    *                                 support add/remove topic without restart
+    * @param messageHandler           Function for translating each message and metadata into the desired type
+    * @tparam K  type of Kafka message key
+    * @tparam V  type of Kafka message value
+    * @tparam KD type of Kafka message key decoder
+    * @tparam VD type of Kafka message value decoder
+    * @tparam R  type returned by messageHandler
+    * @return DStream of R
+    */
+  def createDirectStream[K, V, KD <: Decoder[K], VD <: Decoder[V], R](
+                                                                       jssc: JavaStreamingContext,
+                                                                       keyClass: Class[K],
+                                                                       valueClass: Class[V],
+                                                                       keyDecoderClass: Class[KD],
+                                                                       valueDecoderClass: Class[VD],
+                                                                       recordClass: Class[R],
+                                                                       kafkaParams: JMap[String, String],
+                                                                       fromOffsets: JMap[TopicAndPartition, JLong],
+                                                                       topicAndPartitionHandler: JFunction[Map[TopicAndPartition, Long], Map[TopicAndPartition, Long]],
+                                                                       messageHandler: JFunction[MessageAndMetadata[K, V], R]
+                                                                     ): JavaInputDStream[R] = {
+    implicit val keyCmt: ClassTag[K] = ClassTag(keyClass)
+    implicit val valueCmt: ClassTag[V] = ClassTag(valueClass)
+    implicit val keyDecoderCmt: ClassTag[KD] = ClassTag(keyDecoderClass)
+    implicit val valueDecoderCmt: ClassTag[VD] = ClassTag(valueDecoderClass)
+    implicit val recordCmt: ClassTag[R] = ClassTag(recordClass)
+    val cleanedHandler = jssc.sparkContext.clean(messageHandler.call _)
+    val cleanedTopicAndPartitionHandler = jssc.sparkContext.clean(topicAndPartitionHandler.call _)
+    createDirectStreamWithHandler[K, V, KD, VD, R](
+      jssc.ssc,
+      Map(kafkaParams.asScala.toSeq: _*),
+      Map(fromOffsets.asScala.mapValues(_.longValue()).toSeq: _*),
+      cleanedTopicAndPartitionHandler,
+      cleanedHandler
+    )
+  }
+
+  /**
+    * @param zkServers Zookeeper server string: host1:port1[,host2:port2,...]
+    * @param topic     topic to check for existence
+    * @return { @code true} if and only if the given topic exists
+    */
+  def topicExists(zkServers: String, topic: String): Boolean = {
+    val zkClient: ZkClient = new ZkClient(zkServers, ZK_TIMEOUT_MSEC, ZK_TIMEOUT_MSEC);
+    try {
+      return AdminUtils.topicExists(zkClient, topic);
+    } finally {
+      zkClient.close;
+    }
+  }
+
+  def fillInLatestOffsets(topics: JSet[String], fromOffsets: JMap[TopicAndPartition, JLong], groupId: String, kafkaCluster: KafkaCluster, zkServers: String): Unit = {
+
+    if (topics.isEmpty) {
+      throw new IllegalArgumentException
+    }
+    val zkClient: ZkClient = new ZkClient(zkServers, ZK_TIMEOUT_MSEC, ZK_TIMEOUT_MSEC);
+    try {
+      val effectiveTopics = topics.asScala.filter(topic => AdminUtils.topicExists(zkClient, topic))
+      logInfo("effectiveTopics" + effectiveTopics)
+      val tp = kafkaCluster.getPartitions(effectiveTopics.toSet).right.get
+      tp.foreach(
+        eachTp => {
+          val result = kafkaCluster.getConsumerOffsets(groupId, Set(eachTp))
+          if (result.isLeft) {
+            fromOffsets.put(eachTp, 0L)
+          } else {
+            result.right.get.foreach(tpAndOffset => {
+              fromOffsets.put(tpAndOffset._1, tpAndOffset._2)
+            })
+          }
+        }
+      )
+
+      logInfo("fillInLatestOffsets fromOffsets" + fromOffsets)
+    } finally {
+      zkClient.close;
+    }
+  }
+
+  def refreshOffsets(topics: JSet[String], currentOffsets: JMap[TopicAndPartition, JLong], groupId: String, kafkaCluster: KafkaCluster, zkServers: String): JMap[TopicAndPartition, Long] = {
+    if (topics == null) {
+      //first init
+      return null
+    }
+    val zkClient: ZkClient = new ZkClient(zkServers, ZK_TIMEOUT_MSEC, ZK_TIMEOUT_MSEC);
+    var currentOffsetsWithOutNouseTopic: Map[TopicAndPartition, Long] = Map()
+    try {
+      val effectiveTopics = topics.asScala.filter(topic => AdminUtils.topicExists(zkClient, topic))
+      val tp = kafkaCluster.getPartitions(effectiveTopics.toSet).right.get
+
+      currentOffsets.asScala.keys.foreach(
+        currentTp => {
+          //remove nouse TopicAndPartition
+          if (tp.contains(currentTp)) {
+            val offset = currentOffsets.get(currentTp)
+            currentOffsetsWithOutNouseTopic = currentOffsetsWithOutNouseTopic + (currentTp -> offset)
+          }
+        }
+      )
+
+      tp.foreach(
+        eachTp => {
+          if (!currentOffsetsWithOutNouseTopic.contains(eachTp)) {
+            //add new TopicAndPartition
+            val result = kafkaCluster.getConsumerOffsets(groupId, Set(eachTp))
+            if (result.isLeft) {
+              currentOffsetsWithOutNouseTopic = currentOffsetsWithOutNouseTopic + (eachTp -> 0L)
+            } else {
+              result.right.get.foreach(tpAndOffset => {
+                currentOffsetsWithOutNouseTopic = currentOffsetsWithOutNouseTopic + (tpAndOffset._1 -> tpAndOffset._2)
+              })
+            }
+          }
+        }
+      )
+
+    } finally {
+      zkClient.close;
+    }
+    currentOffsetsWithOutNouseTopic.asJava
+  }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/java/org/apache/eagle/alert/engine/topology/TestUnitSparkTopologyMain.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/java/org/apache/eagle/alert/engine/topology/TestUnitSparkTopologyMain.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.alert.engine.topology;
+
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.eagle.alert.engine.runner.UnitSparkTopologyRunner;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestUnitSparkTopologyMain {
+
+    @Ignore
+    @Test
+    public void testTopologyRun() throws InterruptedException {
+        testTopologyRun("/spark/application-spark.conf");
+    }
+
+    public void testTopologyRun(String configResourceName) throws InterruptedException {
+        ConfigFactory.invalidateCaches();
+        System.setProperty("config.resource", configResourceName);
+        System.out.print("Set config.resource = " + configResourceName);
+        Config config = ConfigFactory.load();
+        new UnitSparkTopologyRunner(config).run();
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        if (args.length > 0) {
+            new TestUnitSparkTopologyMain().testTopologyRun(args[0]);
+        } else {
+            new TestUnitSparkTopologyMain().testTopologyRun();
+        }
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/java/org/apache/eagle/alert/engine/utils/EagleKafkaUtilsTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/java/org/apache/eagle/alert/engine/utils/EagleKafkaUtilsTest.java
@@ -1,0 +1,261 @@
+package org.apache.eagle.alert.engine.utils;
+
+import kafka.common.TopicAndPartition;
+import org.apache.spark.streaming.kafka.EagleKafkaUtils;
+import org.apache.spark.streaming.kafka.KafkaCluster;
+import org.apache.spark.streaming.kafka.KafkaTestUtils;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+
+import java.util.*;
+
+public class EagleKafkaUtilsTest {
+
+    private transient KafkaTestUtils kafkaTestUtils = null;
+    private final String groupId = "test";
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        kafkaTestUtils = new KafkaTestUtils();
+        kafkaTestUtils.setup();
+    }
+
+    @After
+    public void tearDown() {
+        if (kafkaTestUtils != null) {
+            kafkaTestUtils.teardown();
+            kafkaTestUtils = null;
+        }
+    }
+
+    @Test
+    public void testNewTopic() {
+
+        final String topic1 = "topic1";
+        final String topic2 = "topic2";
+        createTopic(topic1);
+        createTopic(topic2);
+        Map<String, String> kafkaParams = new HashMap<>();
+        kafkaParams.put("metadata.broker.list", kafkaTestUtils.brokerAddress());
+        kafkaParams.put("auto.offset.reset", "smallest");
+        kafkaParams.put("group.id", groupId);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        final KafkaCluster kafkaCluster = new KafkaCluster(immutableKafkaParam);
+        Map<TopicAndPartition, Long> fromOffsets = new HashMap<TopicAndPartition, Long>();
+        Set<String> topics = new HashSet<String>();
+        topics.add(topic1);
+        topics.add(topic2);
+        EagleKafkaUtils.fillInLatestOffsets(topics, fromOffsets, groupId, kafkaCluster, kafkaTestUtils.zkAddress());
+        Assert.assertEquals(2, fromOffsets.size());
+        Assert.assertEquals("{[topic2,0]=0, [topic1,0]=0}", fromOffsets.toString());
+    }
+
+
+    @Test
+    public void testOldTopicWithOffsetAndNewTopic() {
+
+        final String topic1 = "topic1";
+        final String topic2 = "topic2";
+        createTopic(topic1);
+        createTopic(topic2);
+        Map<String, String> kafkaParams = new HashMap<>();
+        kafkaParams.put("metadata.broker.list", kafkaTestUtils.brokerAddress());
+        kafkaParams.put("auto.offset.reset", "smallest");
+        kafkaParams.put("group.id", groupId);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        final KafkaCluster kafkaCluster = new KafkaCluster(immutableKafkaParam);
+
+
+        Map<TopicAndPartition, Object> topicAndPartitionObjectMap = new HashMap<TopicAndPartition, Object>();
+        topicAndPartitionObjectMap.put(new TopicAndPartition("topic1", 0), 12L);
+
+        scala.collection.mutable.Map<TopicAndPartition, Object> map = JavaConversions.mapAsScalaMap(topicAndPartitionObjectMap);
+        scala.collection.immutable.Map<TopicAndPartition, Object> scalatopicAndPartitionObjectMap =
+                map.toMap(new Predef.$less$colon$less<Tuple2<TopicAndPartition, Object>, Tuple2<TopicAndPartition, Object>>() {
+                    public Tuple2<TopicAndPartition, Object> apply(Tuple2<TopicAndPartition, Object> v1) {
+                        return v1;
+                    }
+                });
+        kafkaCluster.setConsumerOffsets(groupId, scalatopicAndPartitionObjectMap);
+        Set<String> topics = new HashSet<String>();
+        topics.add(topic1);
+        topics.add(topic2);
+
+        Map<TopicAndPartition, Long> fromOffsets = new HashMap<TopicAndPartition, Long>();
+
+        EagleKafkaUtils.fillInLatestOffsets(topics, fromOffsets, groupId, kafkaCluster, kafkaTestUtils.zkAddress());
+        Assert.assertEquals(2, fromOffsets.size());
+        Assert.assertEquals(new Long(12), fromOffsets.get(new TopicAndPartition("topic1", 0)));
+        Assert.assertEquals(new Long(0), fromOffsets.get(new TopicAndPartition("topic2", 0)));
+    }
+
+    @Test
+    public void testInputEmptyTopics() {
+
+        Map<String, String> kafkaParams = new HashMap<>();
+        kafkaParams.put("metadata.broker.list", kafkaTestUtils.brokerAddress());
+        kafkaParams.put("auto.offset.reset", "smallest");
+        kafkaParams.put("group.id", groupId);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        final KafkaCluster kafkaCluster = new KafkaCluster(immutableKafkaParam);
+        Set<String> topics = new HashSet<String>();
+        Map<TopicAndPartition, Long> fromOffsets = new HashMap<TopicAndPartition, Long>();
+        thrown.expect(IllegalArgumentException.class);
+        EagleKafkaUtils.fillInLatestOffsets(topics, fromOffsets, groupId, kafkaCluster, kafkaTestUtils.zkAddress());
+    }
+
+    @Test
+    public void testRefreshOffsetNoChangTopic(){
+
+        final String topic1 = "topic1";
+        final String topic2 = "topic2";
+        createTopic(topic1);
+        createTopic(topic2);
+
+        Map<String, String> kafkaParams = new HashMap<>();
+        kafkaParams.put("metadata.broker.list", kafkaTestUtils.brokerAddress());
+        kafkaParams.put("auto.offset.reset", "smallest");
+        kafkaParams.put("group.id", groupId);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        final KafkaCluster kafkaCluster = new KafkaCluster(immutableKafkaParam);
+
+        Set<String> topics = new HashSet<String>();
+        topics.add(topic1);
+        topics.add(topic2);
+
+        Map<TopicAndPartition, Long> currentOffsets = new HashMap<TopicAndPartition, Long>();
+        currentOffsets.put(new TopicAndPartition("topic1",0),12L);
+        currentOffsets.put(new TopicAndPartition("topic2",0),2L);
+
+        Map<TopicAndPartition, Object> refreshOffsets = EagleKafkaUtils.refreshOffsets(topics, currentOffsets, groupId, kafkaCluster, kafkaTestUtils.zkAddress());
+
+        Assert.assertEquals(2, currentOffsets.size());
+        Assert.assertEquals(12l, Long.parseLong(refreshOffsets.get(new TopicAndPartition("topic1", 0)).toString()));
+        Assert.assertEquals(2l, Long.parseLong(refreshOffsets.get(new TopicAndPartition("topic2", 0)).toString()));
+
+    }
+
+    @Test
+    public void testRefreshOffsetAddTopic(){
+
+        final String topic1 = "topic1";
+        final String topic2 = "topic2";// new topic
+        createTopic(topic1);
+        createTopic(topic2);
+
+        Map<String, String> kafkaParams = new HashMap<>();
+        kafkaParams.put("metadata.broker.list", kafkaTestUtils.brokerAddress());
+        kafkaParams.put("auto.offset.reset", "smallest");
+        kafkaParams.put("group.id", groupId);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        final KafkaCluster kafkaCluster = new KafkaCluster(immutableKafkaParam);
+
+        Set<String> topics = new HashSet<String>();
+        topics.add(topic1);
+        topics.add(topic2);
+
+        Map<TopicAndPartition, Long> currentOffsets = new HashMap<TopicAndPartition, Long>();
+        currentOffsets.put(new TopicAndPartition("topic1",0),12L);
+
+        Map<TopicAndPartition, Object> refreshOffsets = EagleKafkaUtils.refreshOffsets(topics, currentOffsets, groupId, kafkaCluster, kafkaTestUtils.zkAddress());
+
+        Assert.assertEquals(2, refreshOffsets.size());
+        Assert.assertEquals(12l, Long.parseLong(refreshOffsets.get(new TopicAndPartition("topic1", 0)).toString()));
+        Assert.assertEquals(0l, Long.parseLong(refreshOffsets.get(new TopicAndPartition("topic2", 0)).toString()));
+
+    }
+
+    @Test
+    public void testRefreshOffsetRemoveTopic(){
+
+        final String topic1 = "topic1";
+        final String topic2 = "topic2";
+        createTopic(topic1);
+        createTopic(topic2);
+
+        Map<String, String> kafkaParams = new HashMap<>();
+        kafkaParams.put("metadata.broker.list", kafkaTestUtils.brokerAddress());
+        kafkaParams.put("auto.offset.reset", "smallest");
+        kafkaParams.put("group.id", groupId);
+
+        scala.collection.mutable.Map<String, String> mutableKafkaParam = JavaConversions
+                .mapAsScalaMap(kafkaParams);
+        scala.collection.immutable.Map<String, String> immutableKafkaParam = mutableKafkaParam
+                .toMap(new Predef.$less$colon$less<Tuple2<String, String>, Tuple2<String, String>>() {
+                    public Tuple2<String, String> apply(
+                            Tuple2<String, String> v1) {
+                        return v1;
+                    }
+                });
+        final KafkaCluster kafkaCluster = new KafkaCluster(immutableKafkaParam);
+
+        Set<String> topics = new HashSet<String>();
+        topics.add(topic1);//remove topic2
+
+        Map<TopicAndPartition, Long> currentOffsets = new HashMap<TopicAndPartition, Long>();
+        currentOffsets.put(new TopicAndPartition("topic1",0),12L);
+        currentOffsets.put(new TopicAndPartition("topic2",0),2L);
+
+        Map<TopicAndPartition, Object> refreshOffsets = EagleKafkaUtils.refreshOffsets(topics, currentOffsets, groupId, kafkaCluster, kafkaTestUtils.zkAddress());
+
+        Assert.assertEquals(1, refreshOffsets.size());
+        Assert.assertEquals(12l, Long.parseLong(refreshOffsets.get(new TopicAndPartition("topic1", 0)).toString()));
+
+    }
+
+    private String[] createTopic(String topic) {
+        String[] data = {topic + "-1", topic + "-2", topic + "-3"};
+        kafkaTestUtils.createTopic(topic, 1);
+        return data;
+    }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/java/org/apache/eagle/alert/engine/utils/EagleKafkaUtilsTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/java/org/apache/eagle/alert/engine/utils/EagleKafkaUtilsTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.eagle.alert.engine.utils;
 
 import kafka.common.TopicAndPartition;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/application-spark.conf
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/application-spark.conf
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{
+  "topology": {
+    "name": "alertUnitSparkTopology_3",
+    "batchDuration": 4,
+    "windowDurations": 20,
+    "slideDurations": 20,
+    "groupId": "eagle",
+    "deployMode": "client",
+    "driverCores": 1,
+    "driverMemory": 1g,
+    "core": 1,
+    "checkpointPath": "/tmp",
+    "memory": 1g,
+    "localMode": "true",
+    "master": "",
+    "numOfRouterBolts": 4,
+    "numOfAlertBolts": 2,
+    "numOfPublishTasks": 10
+  },
+  "spout": {
+    "kafkaBrokerZkQuorum": "localhost:9092",
+  },
+  "metadataService": {
+    "context": "/alert/rest",
+    "host": "localhost",
+    "port": 8080
+  },
+  "zkConfig": {
+    "zkQuorum": "localhost:2181",
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/application-spark.conf
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/application-spark.conf
@@ -28,16 +28,16 @@
     "localMode": "true",
     "master": "",
     "numOfRouterBolts": 4,
-    "numOfAlertBolts": 2,
+    "numOfAlertBolts": 4,
     "numOfPublishTasks": 10
   },
   "spout": {
     "kafkaBrokerZkQuorum": "localhost:9092",
   },
   "metadataService": {
-    "context": "/alert/rest",
+    "context": "/rest",
     "host": "localhost",
-    "port": 8080
+    "port": 9090
   },
   "zkConfig": {
     "zkQuorum": "localhost:2181",

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testAlertBoltSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testAlertBoltSpec.json
@@ -1,0 +1,66 @@
+{
+  "version": "version1",
+  "topologyName": "testTopology",
+  "boltPoliciesMap": {
+    "alertBolt0": [
+      {
+        "name": "policy4",
+        "description": "alertBolt0policy4",
+        "inputStreams": [
+          "oozieStream"
+        ],
+        "outputStreams": [
+          "testAlertStream"
+        ],
+        "definition": {
+          "type": "siddhi",
+          "value": " from oozieStream#window.externalTime(timestamp, 4 sec)  select ip, jobId , operation, count(1) as visitCount insert into testAlertStream;  "
+        },
+        "partitionSpec": [
+          {
+            "streamId": "oozieStream",
+            "type": "GROUPBY",
+            "columns": [
+              "operation"
+            ],
+            "sortSpec": {
+              "windowPeriod": "PT4S",
+              "windowMargin": 1000
+            }
+          }
+        ],
+        "parallelismHint": 0
+      }
+    ],
+    "alertBolt1": [
+      {
+        "name": "policy4",
+        "description": "alertBolt1policy4",
+        "inputStreams": [
+          "oozieStream"
+        ],
+        "outputStreams": [
+          "testAlertStream"
+        ],
+        "definition": {
+          "type": "siddhi",
+          "value": " from oozieStream#window.externalTime(timestamp, 2 sec)  select ip, jobId , operation, count(1) as visitCount insert into testAlertStream;  "
+        },
+        "partitionSpec": [
+          {
+            "streamId": "oozieStream",
+            "type": "GROUPBY",
+            "columns": [
+              "operation"
+            ],
+            "sortSpec": {
+              "windowPeriod": "PT4S",
+              "windowMargin": 1000
+            }
+          }
+        ],
+        "parallelismHint": 0
+      }
+    ]
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testPublishSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testPublishSpec.json
@@ -1,0 +1,23 @@
+{
+  "version": "version1",
+  "topologyName": "testTopology",
+  "boltId": "alertPublishBolt",
+  "publishments": [
+    {
+      "type": "org.apache.eagle.alert.engine.publisher.impl.AlertEmailPublisher",
+      "name":"email-testAlertStream",
+      "policyIds": ["policy4"],
+      "dedupIntervalMin": "PT1M",
+      "properties":{
+        "subject":"UMP Test Alert",
+        "template":"",
+        "sender": "sender@corp.com",
+        "recipients": "receiver@corp.com",
+        "smtp.server":"mailhost.com",
+        "connection": "plaintext",
+        "smtp.port": "25"
+      },
+      "serializer" : "org.apache.eagle.alert.engine.publisher.impl.StringEventSerializer"
+    }
+  ]
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testSpoutSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testSpoutSpec.json
@@ -1,0 +1,53 @@
+{
+  "version": null,
+  "topologyId": "testTopology",
+  "kafka2TupleMetadataMap": {
+    "oozie": {
+      "type": null,
+      "name": "oozie",
+      "properties": null,
+      "topic": "oozie",
+      "schemeCls": "org.apache.eagle.alert.engine.scheme.JsonScheme",
+      "codec": null
+    }
+  },
+  "tuple2StreamMetadataMap": {
+    "oozie": {
+      "activeStreamNames": [
+        "oozieStream"
+      ],
+      "streamNameSelectorProp": {
+        "userProvidedStreamName": "oozieStream"
+      },
+      "streamNameSelectorCls": "org.apache.eagle.alert.engine.scheme.PlainStringStreamNameSelector",
+      "timestampColumn": "timestamp",
+      "timestampFormat": null
+    }
+  },
+  "streamRepartitionMetadataMap": {
+    "oozie": [
+      {
+        "topicName": "oozie",
+        "streamId": "defaultStringStream",
+        "groupingStrategies": [
+          {
+            "partition": {
+              "streamId": "oozieStream",
+              "type": "GROUPBY",
+              "columns": [
+                "operation"
+              ],
+              "sortSpec": {
+                "windowPeriod": "PT4S",
+                "windowMargin": 1000
+              }
+            },
+            "numTotalParticipatingRouterBolts": 4,
+            "startSequence": 0,
+            "totalTargetBoltIds": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testStreamDefinitionsSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testStreamDefinitionsSpec.json
@@ -1,0 +1,35 @@
+{
+  "oozieStream": {
+    "streamId": "oozieStream",
+    "dataSource": null,
+    "description": null,
+    "validate": false,
+    "timeseries": false,
+    "columns": [
+      {
+        "name": "ip",
+        "type": "STRING",
+        "defaultValue": null,
+        "required": false
+      },
+      {
+        "name": "jobId",
+        "type": "STRING",
+        "defaultValue": null,
+        "required": false
+      },
+      {
+        "name": "operation",
+        "type": "STRING",
+        "defaultValue": null,
+        "required": false
+      },
+      {
+        "name": "timestamp",
+        "type" : "LONG",
+        "defaultValue": 0,
+        "required":true
+      }
+    ]
+  }
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testStreamRouterBoltSpec.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-spark/src/test/resources/spark/testStreamRouterBoltSpec.json
@@ -1,0 +1,45 @@
+{
+  "version": null,
+  "topologyName": "testTopology",
+  "routerSpecs": [
+    {
+      "streamId": "oozieStream",
+      "partition": {
+        "streamId": "oozieStream",
+        "type": "GROUPBY",
+        "columns": [
+          "operation"
+        ],
+        "sortSpec": {
+          "windowPeriod": "PT4S",
+          "windowMargin": 1000
+        }
+      },
+      "targetQueue": [
+        {
+          "partition": {
+            "streamId": "oozieStream",
+            "type": "GROUPBY",
+            "columns": [
+              "ip"
+            ],
+            "sortSpec": {
+              "windowPeriod": "PT4S",
+              "windowMargin": 1000
+            }
+          },
+          "workers": [
+            {
+              "topologyName": "testTopology",
+              "boltId": "alertBolt0"
+            },
+            {
+              "topologyName": "testTopology",
+              "boltId": "alertBolt1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/pom.xml
+++ b/eagle-core/eagle-alert-parent/eagle-alert/pom.xml
@@ -31,6 +31,7 @@
         <module>alert-assembly</module>
         <module>alert-devtools</module>
         <module>alert-service</module>
+        <module>alert-spark</module>
     </modules>
 
 	<properties>

--- a/eagle-core/eagle-app/eagle-app-base/pom.xml
+++ b/eagle-core/eagle-app/eagle-app-base/pom.xml
@@ -83,6 +83,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>alert-spark</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
             <version>${jersey.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <maprfs.version>5.1.0-mapr</maprfs.version>
         <mapr-hbase.version>0.98.9-mapr-1503</mapr-hbase.version>
 
-        <spark.core.version>1.4.0</spark.core.version>
+        <spark.core.version>2.0.0</spark.core.version>
 
         <!--  Client -->
         <kafka-client.version>0.9.0.0</kafka-client.version>
@@ -211,8 +211,8 @@
 
         <!-- Serialization -->
         <gson.version>2.2.2</gson.version>
-        <guava.version>15.0</guava.version>
-        <fasterxml-jackson.version>2.5.4</fasterxml-jackson.version>
+        <guava.version>19.0</guava.version>
+        <fasterxml-jackson.version>2.6.0</fasterxml-jackson.version>
         <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
         <jsoup.version>1.7.3</jsoup.version>
         <io.netty.version>3.6.7.Final</io.netty.version>


### PR DESCRIPTION
 - EAGLE-424
  - Support kafka add/remove topic without requiring restart of the alert engine 
  - Read spec metadata by restful web app
  - Create UnitSparkTopologyRunner to demo spark streaming usage
 - EAGLE-425
  - Use Spark Accumulator to save and recover state
  - Use Spark Accumulator to support Hybird Time Window  

https://issues.apache.org/jira/browse/EAGLE-348