### PR TITLE
[Eagle 695] fetching hadoop.cluster.allocatedvirtualcores instead of hadoop.cluster.totalvirtualcores

### DIFF
--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/crawler/ClusterMetricsParseListener.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/crawler/ClusterMetricsParseListener.java
@@ -83,7 +83,7 @@ public class ClusterMetricsParseListener {
         createMetric(MetricName.HADOOP_CLUSTER_TOTAL_MEMORY, currentTimestamp, metrics.getTotalMB(), AggregateFunc.MAX);
         createMetric(MetricName.HADOOP_CLUSTER_AVAILABLE_MEMORY, currentTimestamp, metrics.getAvailableMB(), AggregateFunc.AVG);
         createMetric(MetricName.HADOOP_CLUSTER_RESERVED_MEMORY, currentTimestamp, metrics.getReservedMB(), AggregateFunc.AVG);
-        createMetric(MetricName.HADOOP_CLUSTER_TOTAL_VIRTUAL_CORES, currentTimestamp, metrics.getAllocatedVirtualCores(), AggregateFunc.MAX);
+        createMetric(MetricName.HADOOP_CLUSTER_ALLOCATED_VIRTUAL_CORES, currentTimestamp, metrics.getAllocatedVirtualCores(), AggregateFunc.MAX);
     }
 
     public void flush() {

--- a/eagle-jpm/eagle-hadoop-queue/src/main/resources/META-INF/providers/org.apache.eagle.hadoop.queue.HadoopQueueRunningAppProvider.xml
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/resources/META-INF/providers/org.apache.eagle.hadoop.queue.HadoopQueueRunningAppProvider.xml
@@ -43,8 +43,8 @@
     </property>
     <property>
       <name>dataSourceConfig.fetchIntervalSec</name>
-      <displayName>Fetch Interval in Seconds</displayName>
-      <description>fetching interval in seconds</description>
+      <displayName>Fetching Metric Interval in Seconds</displayName>
+      <description>interval seconds of fetching metric from resource manager</description>
       <value>10</value>
     </property>
   </configuration>


### PR DESCRIPTION
Virtual Core related metrics are additional, starting from hadoop version 2.7.x. And we were originally fetching hadoop.cluster.allocatedvirtualcores. Now it seems that hadoop.cluster.totalvirtualcores is more meaningful. So change code to fetch and show it up in hadoop-queue monitoring application.
