### PR TITLE
[EAGLE-697] fix wrong url-concatenation for monitoring hadoop queue

### DIFF
--- a/eagle-jpm/eagle-hadoop-queue/pom.xml
+++ b/eagle-jpm/eagle-hadoop-queue/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>eagle-app-base</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-app-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/common/YarnClusterResourceURLBuilder.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/common/YarnClusterResourceURLBuilder.java
@@ -18,26 +18,29 @@
 
 package org.apache.eagle.hadoop.queue.common;
 
+import org.apache.eagle.app.utils.PathResolverHelper;
+
 public class YarnClusterResourceURLBuilder {
 
-    private static final String CLUSTER_SCHEDULER_API_URL = "ws/v1/cluster/scheduler";
-    private static final String CLUSTER_METRICS_API_URL = "ws/v1/cluster/metrics";
-    private static final String CLUSTER_APPS_API_URL = "ws/v1/cluster/apps";
+    private static final String CLUSTER_SCHEDULER_API_URL = "/ws/v1/cluster/scheduler";
+    private static final String CLUSTER_METRICS_API_URL = "/ws/v1/cluster/metrics";
+    private static final String CLUSTER_APPS_API_URL = "/ws/v1/cluster/apps";
     private static final String ANONYMOUS_PARAMETER = "anonymous=true";
 
     public static String buildSchedulerInfoURL(String urlBase) {
-        return urlBase + CLUSTER_SCHEDULER_API_URL + "?" + ANONYMOUS_PARAMETER;
+        return PathResolverHelper.buildUrlPath(urlBase, CLUSTER_SCHEDULER_API_URL + "?" + ANONYMOUS_PARAMETER);
     }
 
     public static String buildClusterMetricsURL(String urlBase) {
-        return urlBase + CLUSTER_METRICS_API_URL + "?" + ANONYMOUS_PARAMETER;
+        return PathResolverHelper.buildUrlPath(urlBase, CLUSTER_METRICS_API_URL + "?" + ANONYMOUS_PARAMETER);
     }
 
     public static String buildRunningAppsURL(String urlBase) {
-        return urlBase + CLUSTER_APPS_API_URL + "?state=RUNNING" + "&" + ANONYMOUS_PARAMETER;
+        return PathResolverHelper.buildUrlPath(urlBase, CLUSTER_APPS_API_URL + "?state=RUNNING" + "&" + ANONYMOUS_PARAMETER);
     }
 
     public static String buildFinishedAppsURL(String urlBase) {
-        return urlBase + CLUSTER_APPS_API_URL + "?state=FINISHED" + "&" + ANONYMOUS_PARAMETER;
+        return PathResolverHelper.buildUrlPath(urlBase, CLUSTER_APPS_API_URL + "?state=FINISHED" + "&" + ANONYMOUS_PARAMETER);
     }
+
 }

--- a/eagle-jpm/eagle-hadoop-queue/src/test/java/org/apache/eagle/hadoop/queue/common/YarnClusterResourceURLBuilderTest.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/test/java/org/apache/eagle/hadoop/queue/common/YarnClusterResourceURLBuilderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.hadoop.queue.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class YarnClusterResourceURLBuilderTest {
+
+    private static final String BASE_URL_WITH_TAILING_SLASH = "https://baseurl.with.tailing.slash:8080/";
+    private static final String BASE_URL_WITHOUT_TAILING_SLASH = "https://baseurl.with.tailing.slash:8080";
+
+    private static final String EXPECTED_SCHEDULER_INFO_URL = "https://baseurl.with.tailing.slash:8080/ws/v1/cluster/scheduler?anonymous=true";
+    private static final String EXPECTED_CLUSTER_METRICS_URL = "https://baseurl.with.tailing.slash:8080/ws/v1/cluster/metrics?anonymous=true";
+    private static final String EXPECTED_RUNNING_APP_URL = "https://baseurl.with.tailing.slash:8080/ws/v1/cluster/apps?state=RUNNING&anonymous=true";
+    private static final String EXPECTED_FINISHED_APPS_URL = "https://baseurl.with.tailing.slash:8080/ws/v1/cluster/apps?state=FINISHED&anonymous=true";
+
+    @Test
+    public void testBuildSchedulerInfoURLWithBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildSchedulerInfoURL(BASE_URL_WITH_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching scheduler info", EXPECTED_SCHEDULER_INFO_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildClusterMetricsURLWithBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildClusterMetricsURL(BASE_URL_WITH_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching cluster metrics", EXPECTED_CLUSTER_METRICS_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildRunningAppsURLWithBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildRunningAppsURL(BASE_URL_WITH_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching running apps", EXPECTED_RUNNING_APP_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildFinishedAppsURLWithBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildFinishedAppsURL(BASE_URL_WITH_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching finished apps", EXPECTED_FINISHED_APPS_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildSchedulerInfoURLWithoutBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildSchedulerInfoURL(BASE_URL_WITHOUT_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching scheduler info", EXPECTED_SCHEDULER_INFO_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildClusterMetricsURLWithoutBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildClusterMetricsURL(BASE_URL_WITHOUT_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching cluster metrics", EXPECTED_CLUSTER_METRICS_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildRunningAppsURLWithoutBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildRunningAppsURL(BASE_URL_WITHOUT_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching running apps", EXPECTED_RUNNING_APP_URL, resolvedUrl);
+    }
+
+    @Test
+    public void testBuildFinishedAppsURLWithoutBaseURLTailingSlash() {
+        String resolvedUrl = YarnClusterResourceURLBuilder.buildFinishedAppsURL(BASE_URL_WITHOUT_TAILING_SLASH);
+        Assert.assertEquals("unexpected url composed for fetching finished apps", EXPECTED_FINISHED_APPS_URL, resolvedUrl);
+    }
+}


### PR DESCRIPTION
For hadoop queue monitoring, when endpoint url doesn't end with a slash, the final url will be composed by concatenating endpoint directly with resource path. E.g.
endpoint: https://a.b.c:1111
resource path: ws/v1/cluster/some
Then final url is: https://a.b.c:1111ws/v1/cluster/some, which make application fail.
We should add "/" to existing constants of resource paths, and compose final url with utils.
Besides, add concrete unit test to guarantee this part functions normally.