### PR TITLE
[EAGLE-727] Fix TestGroupAggregateTimeSeriesClient and TestGroupAggregateClient

### DIFF
--- a/eagle-core/eagle-embed/eagle-embed-hbase/src/main/java/org/apache/eagle/service/hbase/EmbeddedHbase.java
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/src/main/java/org/apache/eagle/service/hbase/EmbeddedHbase.java
@@ -42,26 +42,37 @@ public class EmbeddedHbase {
         this(port, DEFAULT_ZNODE);
     }
     
-    public static EmbeddedHbase getInstance() {
+    public static EmbeddedHbase getInstance(Configuration conf) {
         if (hbase == null) {
             synchronized (EmbeddedHbase.class) {
                 if (hbase == null) {
                     hbase = new EmbeddedHbase();
-                    hbase.start();                           
+                    hbase.start(conf);
                 }
             }
         }
         return hbase;
     }
-    
+
+    public static EmbeddedHbase getInstance() {
+        return  getInstance(null);
+    }
+
     private EmbeddedHbase() {
         this(DEFAULT_PORT, DEFAULT_ZNODE);
     }
 
     public void start() {
+        start(null);
+    }
+
+    public void start(Configuration confMap) {
         try {
             util = new HBaseTestingUtility();
             Configuration conf = util.getConfiguration();
+            if(confMap != null) {
+                conf.addResource(confMap);
+            }
             conf.setInt("test.hbase.zookeeper.property.clientPort", port);
             conf.set("zookeeper.znode.parent", znode);
             conf.setInt("hbase.zookeeper.property.maxClientCnxns", 200);

--- a/eagle-core/eagle-embed/eagle-embed-hbase/src/test/java/org/apache/eagle/service/hbase/TestHBaseBase.java
+++ b/eagle-core/eagle-embed/eagle-embed-hbase/src/test/java/org/apache/eagle/service/hbase/TestHBaseBase.java
@@ -16,10 +16,10 @@
  */
 package org.apache.eagle.service.hbase;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.*;
+
+
 
 @Ignore
 public class TestHBaseBase {
@@ -28,6 +28,11 @@ public class TestHBaseBase {
     @BeforeClass
     public static void setUpHBase() {
         hbase = EmbeddedHbase.getInstance();
+    }
+
+    public static void setupHBaseWithConfig(Configuration config){
+        Assert.assertTrue("HBase test mini cluster should not start",null == hbase);
+        hbase = EmbeddedHbase.getInstance(config);
     }
 
     @AfterClass

--- a/eagle-core/eagle-query/eagle-storage-hbase/src/test/java/org/apache/eagle/storage/hbase/aggregate/coprocessor/TestGroupAggregateClient.java
+++ b/eagle-core/eagle-query/eagle-storage-hbase/src/test/java/org/apache/eagle/storage/hbase/aggregate/coprocessor/TestGroupAggregateClient.java
@@ -23,12 +23,15 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.eagle.common.config.EagleConfigFactory;
+import org.apache.eagle.storage.hbase.query.coprocessor.AggregateProtocolEndPoint;
 import org.apache.eagle.storage.hbase.query.coprocessor.impl.AggregateClientImpl;
 
 import org.apache.eagle.storage.hbase.query.coprocessor.AggregateClient;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HTableFactory;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DoubleWritable;
 import org.junit.*;
@@ -50,7 +53,6 @@ import org.apache.eagle.service.hbase.TestHBaseBase;
 /**
  * @since : 10/30/14,2014
  */
-@Ignore
 public class TestGroupAggregateClient extends TestHBaseBase {
     HTableInterface table;
     long startTime;
@@ -61,6 +63,14 @@ public class TestGroupAggregateClient extends TestHBaseBase {
     int num = 200;
 
     private final static Logger LOG = LoggerFactory.getLogger(TestGroupAggregateClient.class);
+
+    // This is Bad, It will hide TestHBaseBase.setUpHBase!!!!
+    @BeforeClass
+    public static void setUpHBase() {
+        Configuration conf = new Configuration();
+        conf.setStrings(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,AggregateProtocolEndPoint.class.getName());
+        TestHBaseBase.setupHBaseWithConfig(conf);
+    }
 
     @Before
     public void setUp() {

--- a/eagle-core/eagle-query/eagle-storage-hbase/src/test/java/org/apache/eagle/storage/hbase/aggregate/coprocessor/TestGroupAggregateTimeSeriesClient.java
+++ b/eagle-core/eagle-query/eagle-storage-hbase/src/test/java/org/apache/eagle/storage/hbase/aggregate/coprocessor/TestGroupAggregateTimeSeriesClient.java
@@ -22,6 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.eagle.common.config.EagleConfigFactory;
+import org.apache.eagle.storage.hbase.query.coprocessor.AggregateProtocolEndPoint;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
 import org.junit.Assert;
 
 import org.apache.eagle.storage.hbase.query.coprocessor.AggregateClient;
@@ -30,7 +33,8 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DoubleWritable;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +53,6 @@ import org.apache.eagle.storage.hbase.query.coprocessor.impl.AggregateClientImpl
 /**
  * @since : 11/10/14,2014
  */
-@Ignore
 public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
 
     private final static Logger LOG = LoggerFactory.getLogger(TestGroupAggregateTimeSeriesClient.class);
@@ -61,6 +64,14 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
     AggregateClient client;
     Scan scan;
     EntityDefinition ed;
+
+    // This is Bad, It will hide TestHBaseBase.setUpHBase!!!!
+    @BeforeClass
+    public static void setUpHBase() {
+        Configuration conf = new Configuration();
+        conf.setStrings(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,AggregateProtocolEndPoint.class.getName());
+        TestHBaseBase.setupHBaseWithConfig(conf);
+    }
 
     @Before
     public void setUp() throws IllegalAccessException, InstantiationException {
@@ -121,7 +132,7 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
     }
 
 
-    //@Test
+    @Test
     public void testGroupTimeSeriesAggCountClient() {
         try {
             List<GroupbyKeyValue> result = client.aggregate(table, ed, scan, Arrays.asList("cluster", "datacenter"), Arrays.asList(AggregateFunctionType.count), Arrays.asList("count"), true, startTime, System.currentTimeMillis(), 10).getKeyValues();
@@ -134,7 +145,7 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
         }
     }
 
-    //@Test
+    @Test
     public void testGroupTimeSeriesAggMaxClient() {
         try {
             List<GroupbyKeyValue> result = client.aggregate(table, ed, scan, Arrays.asList("cluster", "datacenter"), Arrays.asList(AggregateFunctionType.max), Arrays.asList("field2"), true, startTime, System.currentTimeMillis(), 10).getKeyValues();
@@ -147,7 +158,7 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
         }
     }
 
-    //@Test
+    @Test
     public void testGroupTimeSeriesAggMinClient() {
         try {
             List<GroupbyKeyValue> result = client.aggregate(table, ed, scan, Arrays.asList("cluster", "datacenter"), Arrays.asList(AggregateFunctionType.min), Arrays.asList("field2"), true, startTime, System.currentTimeMillis(), 10).getKeyValues();
@@ -160,7 +171,7 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
         }
     }
 
-    //@Test
+    @Test
     public void testGroupTimeSeriesAggAvgClient() {
         try {
             List<GroupbyKeyValue> result = client.aggregate(table, ed, scan, Arrays.asList("cluster", "datacenter"), Arrays.asList(AggregateFunctionType.min), Arrays.asList("field2"), true, startTime, System.currentTimeMillis(), 10).getKeyValues();
@@ -173,7 +184,7 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
         }
     }
 
-    //@Test
+    @Test
     public void testGroupTimeSeriesAggSumClient() {
         try {
             List<GroupbyKeyValue> result = client.aggregate(table, ed, scan, Arrays.asList("cluster", "datacenter"), Arrays.asList(AggregateFunctionType.sum), Arrays.asList("field2"), true, startTime, System.currentTimeMillis(), 10).getKeyValues();
@@ -186,7 +197,7 @@ public class TestGroupAggregateTimeSeriesClient extends TestHBaseBase {
         }
     }
 
-    //@Test
+    @Test
     public void testGroupTimeSeriesAggMultipleClient() {
         try {
             List<GroupbyKeyValue> result = client.aggregate(table, ed, scan,


### PR DESCRIPTION
TestGroupAggregateTimeSeriesClient and TestGroupAggregateClient can't run correctly due to without setting hbase.coprocessor.region.classes