### PR TITLE
[Minor] : Exclude jetty & old servlet-api

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-service/pom.xml
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-service/pom.xml
@@ -37,6 +37,14 @@
                     <artifactId>storm-core</artifactId>
                     <groupId>org.apache.storm</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>servlet-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty</artifactId>
+                    <groupId>org.mortbay.jetty</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Dropwizard, hadoop and Jetty (included by eagle-common module) depends on different version servlet-api, it causes jar conflicts issue.