### PR TITLE
EAGLE-756: make sure publish change is sent to runtime bolts

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertPublisherImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertPublisherImpl.java
@@ -173,7 +173,10 @@ public class AlertPublisherImpl implements AlertPublisher {
                 addPublishmentPoliciesStreams(newPSPublishPluginMapping, newPolicies, newStreams, pubName);
             }
             Publishment newPub = afterModified.get(i);
-            newPublishMap.get(pubName).update(newPub.getDedupIntervalMin(), newPub.getProperties());
+
+            // for updated publishment, need to init them too
+            AlertPublishPlugin newPlugin = AlertPublishPluginsFactory.createNotificationPlugin(newPub, config, conf);
+            newPublishMap.replace(pubName, newPlugin);
         }
 
         // now do the swap


### PR DESCRIPTION
During test with Alert Engine publisher, it looks like when we have slack publishment, the metadata reload become slow refreshed when use change the metadata and manually trigger the coordinator schedule.