### PR TITLE
EAGLE-758: Add tuple log for spout & alert bolt

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/AlertBolt.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/AlertBolt.java
@@ -16,7 +16,11 @@
  */
 package org.apache.eagle.alert.engine.runner;
 
-import backtype.storm.metric.api.IMetric;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
 import org.apache.eagle.alert.coordination.model.AlertBoltSpec;
 import org.apache.eagle.alert.coordination.model.WorkSlot;
 import org.apache.eagle.alert.engine.AlertStreamCollector;
@@ -35,6 +39,10 @@ import org.apache.eagle.alert.engine.utils.SingletonExecutor;
 import org.apache.eagle.alert.service.IMetadataServiceClient;
 import org.apache.eagle.alert.service.MetadataServiceClientImpl;
 import org.apache.eagle.alert.utils.AlertConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.typesafe.config.Config;
 
 import backtype.storm.metric.api.MultiCountMetric;
 import backtype.storm.task.OutputCollector;
@@ -42,14 +50,6 @@ import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
-import com.typesafe.config.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Since 5/1/16.
@@ -81,6 +81,7 @@ public class AlertBolt extends AbstractStreamBolt implements AlertBoltSpecListen
         this.streamContext.counter().scope("execute_count").incr();
         try {
             PartitionedEvent pe = deserialize(input.getValueByField(AlertConstants.FIELD_0));
+            LOG.info("Alert bolt {} received event: {}", boltId, pe.getEvent());
             String streamEventVersion = pe.getEvent().getMetaVersion();
 
             if (streamEventVersion == null) {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/spout/SpoutOutputCollectorWrapper.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/spout/SpoutOutputCollectorWrapper.java
@@ -103,7 +103,7 @@ public class SpoutOutputCollectorWrapper extends SpoutOutputCollector implements
          */
         List<Object> convertedTuple = converter.convert(tuple);
         if (convertedTuple == null) {
-            LOG.warn("source data {} can't be converted to a stream, ignore this message", tuple);
+            LOG.debug("source data {} can't be converted to a stream, ignore this message", tuple);
             spout.ack(newMessageId);
             return null;
         }
@@ -118,6 +118,8 @@ public class SpoutOutputCollectorWrapper extends SpoutOutputCollector implements
         }
 
         StreamEvent event = convertToStreamEventByStreamDefinition((Long) convertedTuple.get(2), m, sds.get(streamId));
+        LOG.info("Spout from topic {} emit event: {}", topic, event);
+        
         /*
             phase 2: stream repartition
         */


### PR DESCRIPTION
Without tuple log for spout & alert bolt, it is hard to troubleshoot event missing issue, we don't know whether the spout/alert process issue or no event come.