### PR TITLE
[EAGLE-766] Set default host & port of JPM_WEB_APP as null

### DIFF
--- a/eagle-jpm/eagle-jpm-web/src/main/resources/META-INF/providers/org.apache.eagle.app.jpm.JPMWebApplicationProvider.xml
+++ b/eagle-jpm/eagle-jpm-web/src/main/resources/META-INF/providers/org.apache.eagle.app.jpm.JPMWebApplicationProvider.xml
@@ -43,15 +43,13 @@
     <configuration>
         <property>
             <name>service.host</name>
-            <value>localhost</value>
             <displayName>Eagle Service Host</displayName>
-            <description>Eagle Service Host, default: localhost</description>
+            <description>Set additional eagle service host, default: using current host</description>
         </property>
         <property>
             <name>service.port</name>
-            <value>8080</value>
             <displayName>Eagle Service Port</displayName>
-            <description>Eagle Service Port, default: 8080</description>
+            <description>Set additional eagle service port, default: using current port</description>
         </property>
     </configuration>
 </application>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-766

Set default host & port of JPM_WEB_APP as N/A to make sure the web will read web service from configured instead of always using current.
