### PR TITLE
[EAGLE-773] org.apache.eagle.service.generic.MetaDataResource doesn't work correctly

### DIFF
--- a/eagle-core/eagle-query/eagle-service-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-service-base/pom.xml
@@ -50,17 +50,59 @@
             <groupId>org.apache.eagle</groupId>
             <artifactId>eagle-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.eagle</groupId>
             <artifactId>eagle-storage-hbase</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.eagle</groupId>
             <artifactId>eagle-embed-hbase</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.eagle</groupId>
@@ -68,6 +110,34 @@
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${dropwizard.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-jvm</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>${metrics.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.orbit</groupId>
+            <artifactId>javax.servlet</artifactId>
+            <version>${org.eclipse.jetty.orbit.javax.servlet.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>org.codehaus.jackson</groupId>-->

--- a/eagle-core/eagle-query/eagle-service-base/src/main/java/org/apache/eagle/service/generic/MetadataResource.java
+++ b/eagle-core/eagle-query/eagle-service-base/src/main/java/org/apache/eagle/service/generic/MetadataResource.java
@@ -25,10 +25,10 @@ import com.sun.jersey.api.model.AbstractResourceMethod;
 import com.sun.jersey.api.model.AbstractSubResourceMethod;
 import com.sun.jersey.server.impl.modelapi.annotation.IntrospectionModeller;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.JsonNodeFactory;
-import org.codehaus.jackson.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
@@ -50,6 +50,12 @@ public class MetadataResource {
 	final static String PATH_RESOURCE = "resource";
 	final static String PATH_SERVICE = "service";
 
+	final static String SERVICE_COUNT = "count";
+	final static String SERVICE_SERVICES = "services";
+
+	final static String RESOURCE_BASE = "base";
+	final static String RESOURCE_RESOURCES = "resources";
+
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response index(@Context Application application,
@@ -70,9 +76,9 @@ public class MetadataResource {
 		String basePath = request.getRequestURL().toString();
 		basePath = basePath.substring(0,basePath.length() - PATH_META.length() - PATH_RESOURCE.length() -1);
 		ObjectNode root = JsonNodeFactory.instance.objectNode();
-		root.put("base",basePath);
+		root.put(RESOURCE_BASE,basePath);
 		ArrayNode resources = JsonNodeFactory.instance.arrayNode();
-		root.put( "resources", resources );
+		root.put( RESOURCE_RESOURCES, resources );
 
 		for ( Class<?> aClass : application.getClasses()){
 			if ( isAnnotatedResourceClass(aClass)){
@@ -145,8 +151,9 @@ public class MetadataResource {
 //			serviceNode.put(entry.getKey(),entityDefationitionAsJson(entry.getValue()));
 			services.add(entityDefationitionAsJson(entry.getValue()));
 		}
-		root.put("count",entities.keySet().size());
-		root.put("services",services);
+
+		root.put(SERVICE_COUNT,entities.keySet().size());
+		root.put(SERVICE_SERVICES,services);
 		return Response.ok().entity(root).build();
 	}
 

--- a/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/MetadataResourceApp.java
+++ b/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/MetadataResourceApp.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.service.generic;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.server.DefaultServerFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+
+public class MetadataResourceApp extends Application<Configuration> {
+
+    @Override
+    public void initialize(Bootstrap<Configuration> bootstrap) {
+    }
+
+    @Override
+    public void run(Configuration configuration, Environment environment) throws Exception {
+        ((HttpConnectorFactory) ((DefaultServerFactory) configuration.getServerFactory()).getApplicationConnectors().get(0)).setPort(0);
+        ((HttpConnectorFactory) ((DefaultServerFactory) configuration.getServerFactory()).getAdminConnectors().get(0)).setPort(0);
+        environment.jersey().register(MetadataResource.class);
+    }
+}

--- a/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestMetadataResource.java
+++ b/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestMetadataResource.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eagle.service.generic;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.jersey.api.client.Client;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import javax.ws.rs.core.MediaType;
+
+import static javax.ws.rs.core.HttpHeaders.*;
+
+
+public class TestMetadataResource {
+
+    private String restURL;
+    private String restMetaURL;
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> RULE =
+        new DropwizardAppRule<>(MetadataResourceApp.class, null);
+
+
+    private ObjectNode getMetadataResource(String url){
+        return new Client().resource(restMetaURL + url )
+            .header(ACCEPT, MediaType.APPLICATION_JSON)
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .get(ObjectNode.class);
+    }
+
+    @Before
+    public void setUp()
+    {
+        restURL = "http://localhost:" + RULE.getLocalPort() + "/";
+        restMetaURL = restURL +MetadataResource.PATH_META + "/";
+    }
+    @Test
+    public void testListResource() {
+        final ObjectNode clientResponse = getMetadataResource(MetadataResource.PATH_RESOURCE);
+        Assert.assertEquals(2, clientResponse.size());
+        Assert.assertEquals(restURL,clientResponse.get(MetadataResource.RESOURCE_BASE).textValue());
+        Assert.assertEquals(1,clientResponse.get(MetadataResource.RESOURCE_RESOURCES).size());
+
+        JsonNode node = clientResponse.get(MetadataResource.RESOURCE_RESOURCES).get(0);
+        Assert.assertEquals(3,node.size());
+        Assert.assertNotNull(node.get(MetadataResource.PATH_META));
+        Assert.assertNotNull(node.get(MetadataResource.PATH_META+"/"+MetadataResource.PATH_SERVICE));
+        Assert.assertNotNull(node.get(MetadataResource.PATH_META+"/"+MetadataResource.PATH_RESOURCE));
+    }
+    @Test
+    public void testListService() {
+        final ObjectNode clientResponse = getMetadataResource(MetadataResource.PATH_SERVICE);
+
+        // EntityRepositoryScanner automatically scans entities, so we can't control the registered "services".
+        // And hence we only verify summary here
+        Assert.assertEquals(2, clientResponse.size());
+        Assert.assertNotNull(clientResponse.get(MetadataResource.SERVICE_COUNT));
+        Assert.assertNotNull(clientResponse.get(MetadataResource.SERVICE_SERVICES));
+    }
+    @Test
+    public void testListMeta() {
+        final ObjectNode clientResponse = getMetadataResource("");
+        Assert.assertEquals(2, clientResponse.size());
+        Assert.assertEquals(restMetaURL+MetadataResource.PATH_SERVICE,clientResponse.get(MetadataResource.PATH_SERVICE).textValue());
+        Assert.assertEquals(restMetaURL+MetadataResource.PATH_RESOURCE,clientResponse.get(MetadataResource.PATH_RESOURCE).textValue());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,8 @@
         <!-- dropwizard -->
         <dropwizard.version>0.7.1</dropwizard.version>
         <dropwizard-guice.version>0.7.0.2</dropwizard-guice.version>
+        <!-- serverlet which dropwizard depends on-->
+        <org.eclipse.jetty.orbit.javax.servlet.version>3.0.0.v201112011016</org.eclipse.jetty.orbit.javax.servlet.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This commit fixes this issue and also adds UT to make sure it.

However, for introducing io.dropwizard:dropwizard-testing, we need specify the following dependencies:

1 only using logback for dropwizard
2 only using org.eclipse.jetty.orbit:javax.servlet
3 only using io.dropwizard.metrics:metrics-core and io.dropwizard.metrics:metrics-jvm

All of these are done by excluding other jars