### PR TITLE
EAGLE-794: enable publish bolt parallelism

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/AlertBoltSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/AlertBoltSpec.java
@@ -17,12 +17,17 @@
 package org.apache.eagle.alert.coordination.model;
 
 import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.coordinator.PublishPartition;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Joiner;
+
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The alert specification for topology bolts.
@@ -39,6 +44,8 @@ public class AlertBoltSpec {
 
     // mapping from boltId to list of PolicyDefinition's Ids
     private Map<String, List<String>> boltPolicyIdsMap = new HashMap<String, List<String>>();
+
+    private Set<PublishPartition> publishPartitions = new HashSet<>();
 
     public AlertBoltSpec() {
     }
@@ -87,6 +94,18 @@ public class AlertBoltSpec {
         }
     }
 
+    public Set<PublishPartition> getPublishPartitions() {
+        return publishPartitions;
+    }
+
+    public void setPublishPartitions(Set<PublishPartition> publishPartitions) {
+        this.publishPartitions = publishPartitions;
+    }
+
+    public void addPublishPartition(String streamId, String policyId, String publishId, Set<String> columns) {
+        this.publishPartitions.add(new PublishPartition(streamId, policyId, publishId, columns));
+    }
+
     @JsonIgnore
     public Map<String, List<PolicyDefinition>> getBoltPoliciesMap() {
         return boltPoliciesMap;
@@ -107,7 +126,8 @@ public class AlertBoltSpec {
 
     @Override
     public String toString() {
-        return String.format("version:%s-topo:%s, boltPolicyIdsMap %s", version, topologyName, boltPolicyIdsMap);
+        return String.format("version:%s-topo:%s, boltPolicyIdsMap %s, publishPartitions %s",
+            version, topologyName, boltPolicyIdsMap, Joiner.on(",").join(publishPartitions));
     }
 
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PublishPartition.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/PublishPartition.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.eagle.alert.engine.coordinator;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Objects;
+
+public class PublishPartition implements Serializable {
+
+    private static final long serialVersionUID = 2524776632955586234L;
+
+    private String policyId;
+    private String streamId;
+    private String publishId;
+    private Set<String> columns = new HashSet<>();
+
+    @JsonIgnore
+    private Set<Object> columnValues = new HashSet<>();
+
+    public PublishPartition() {
+    }
+
+    public PublishPartition(String streamId, String policyId, String publishId, Set<String> columns) {
+        this.streamId = streamId;
+        this.policyId = policyId;
+        this.publishId = publishId;
+        if (columns != null) {
+            this.columns = columns;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(streamId).append(policyId).append(publishId).append(columns).append(columnValues).build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof PublishPartition
+            && Objects.equal(this.streamId, ((PublishPartition) obj).getStreamId())
+            && Objects.equal(this.policyId, ((PublishPartition) obj).getPolicyId())
+            && Objects.equal(this.publishId, ((PublishPartition) obj).getPublishId())
+            && CollectionUtils.isEqualCollection(this.columns, ((PublishPartition) obj).getColumns())
+            && CollectionUtils.isEqualCollection(this.columnValues, ((PublishPartition) obj).getColumnValues());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PublishPartition[policyId=%s,streamId=%s,publishId=%s,columns=%s,columnValues=%s]",
+            policyId, streamId, publishId, columns, columnValues);
+    }
+
+    @Override
+    public PublishPartition clone() {
+        return new PublishPartition(this.streamId, this.policyId, this.publishId, new HashSet<>(this.columns));
+    }
+
+    public String getPolicyId() {
+        return policyId;
+    }
+
+    public void setPolicyId(String policyId) {
+        this.policyId = policyId;
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public void setStreamId(String streamId) {
+        this.streamId = streamId;
+    }
+
+    public String getPublishId() {
+        return publishId;
+    }
+
+    public void setPublishId(String publishId) {
+        this.publishId = publishId;
+    }
+
+    public Set<String> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(Set<String> columns) {
+        this.columns = columns;
+    }
+
+    @JsonIgnore
+    public Set<Object> getColumnValues() {
+        return columnValues;
+    }
+
+    @JsonIgnore
+    public void setColumnValues(Set<Object> columnValues) {
+        this.columnValues = columnValues;
+    }
+
+}

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/Publishment.java
@@ -19,15 +19,19 @@ package org.apache.eagle.alert.engine.coordinator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @since Apr 11, 2016.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Publishment {
+
+    public static final String STREAM_NAME_DEFAULT = "_default";
 
     private String name;
     private String type;
@@ -41,6 +45,16 @@ public class Publishment {
     private Map<String, Object> properties;
     // the class name to extend the IEventSerializer interface
     private String serializer;
+
+    private Set<String> partitionColumns = new HashSet<>();
+
+    public Set<String> getPartitionColumns() {
+        return partitionColumns;
+    }
+
+    public void setPartitionColumns(Set<String> partitionColumns) {
+        this.partitionColumns = partitionColumns;
+    }
 
     public String getName() {
         return name;
@@ -135,13 +149,13 @@ public class Publishment {
         if (obj instanceof Publishment) {
             Publishment p = (Publishment) obj;
             return (Objects.equals(name, p.getName()) && Objects.equals(type, p.getType())
-                    && Objects.equals(dedupIntervalMin, p.getDedupIntervalMin())
-                    && Objects.equals(dedupFields, p.getDedupFields())
-                    && Objects.equals(dedupStateField, p.getDedupStateField())
-                    && Objects.equals(overrideDeduplicator, p.getOverrideDeduplicator())
-                    && Objects.equals(policyIds, p.getPolicyIds())
-                    && Objects.equals(streamIds, p.getStreamIds())
-                    && properties.equals(p.getProperties()));
+                && Objects.equals(dedupIntervalMin, p.getDedupIntervalMin())
+                && Objects.equals(dedupFields, p.getDedupFields())
+                && Objects.equals(dedupStateField, p.getDedupStateField())
+                && Objects.equals(overrideDeduplicator, p.getOverrideDeduplicator())
+                && Objects.equals(policyIds, p.getPolicyIds())
+                && Objects.equals(streamIds, p.getStreamIds())
+                && properties.equals(p.getProperties()));
         }
         return false;
     }
@@ -149,15 +163,15 @@ public class Publishment {
     @Override
     public int hashCode() {
         return new HashCodeBuilder().append(name).append(type).append(dedupIntervalMin).append(dedupFields)
-                .append(dedupStateField).append(overrideDeduplicator).append(policyIds).append(streamIds)
-                .append(properties).build();
+            .append(dedupStateField).append(overrideDeduplicator).append(policyIds).append(streamIds)
+            .append(properties).build();
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Publishment[name:").append(name).append(",type:").append(type).append(",policyId:")
-                .append(policyIds).append(",properties:").append(properties);
+            .append(policyIds).append(",properties:").append(properties);
         return sb.toString();
     }
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/impl/MonitorMetadataGenerator.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/impl/MonitorMetadataGenerator.java
@@ -38,7 +38,6 @@ import java.util.Map;
 
 /**
  * Given current policy placement, figure out monitor metadata
- *
  * <p>TODO: refactor to eliminate the duplicate of stupid if-notInMap-then-create....
  * FIXME: too many duplicated code logic : check null; add list to map; add to list..</p>
  *
@@ -136,6 +135,23 @@ public class MonitorMetadataGenerator {
                 for (String policyName : boltUsage.getPolicies()) {
                     PolicyDefinition definition = context.getPolicies().get(policyName);
                     alertSpec.addBoltPolicy(boltUsage.getBoltId(), definition.getName());
+
+                    for (Publishment publish : context.getPublishments().values()) {
+                        if (!publish.getPolicyIds().contains(definition.getName())) {
+                            continue;
+                        }
+
+                        List<String> streamIds = new ArrayList<>();
+                        // add the publish to the bolt
+                        if (publish.getStreamIds() == null || publish.getStreamIds().size() <= 0) {
+                            streamIds.add(Publishment.STREAM_NAME_DEFAULT);
+                        } else {
+                            streamIds.addAll(publish.getStreamIds());
+                        }
+                        for (String streamId : streamIds) {
+                            alertSpec.addPublishPartition(streamId, policyName, publish.getName(), publish.getPartitionColumns());
+                        }
+                    }
                 }
             }
         }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/AlertBoltOutputCollectorWrapper.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/AlertBoltOutputCollectorWrapper.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,29 +16,57 @@
  */
 package org.apache.eagle.alert.engine.evaluator.impl;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.eagle.alert.engine.AlertStreamCollector;
 import org.apache.eagle.alert.engine.StreamContext;
+import org.apache.eagle.alert.engine.coordinator.PublishPartition;
 import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import backtype.storm.task.OutputCollector;
 
-import java.util.Arrays;
-
 public class AlertBoltOutputCollectorWrapper implements AlertStreamCollector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlertBoltOutputCollectorWrapper.class);
+
     private final OutputCollector delegate;
     private final Object outputLock;
     private final StreamContext streamContext;
 
-    public AlertBoltOutputCollectorWrapper(OutputCollector outputCollector, Object outputLock, StreamContext streamContext) {
+    private volatile Set<PublishPartition> publishPartitions;
+
+    public AlertBoltOutputCollectorWrapper(OutputCollector outputCollector, Object outputLock,
+                                           StreamContext streamContext) {
         this.delegate = outputCollector;
         this.outputLock = outputLock;
         this.streamContext = streamContext;
+
+        this.publishPartitions = new HashSet<>();
     }
 
     @Override
     public void emit(AlertStreamEvent event) {
-        synchronized (outputLock) {
-            streamContext.counter().scope("alert_count").incr();
-            delegate.emit(Arrays.asList(event.getStreamId(), event));
+        Set<PublishPartition> clonedPublishPartitions = new HashSet<>(publishPartitions);
+        for (PublishPartition publishPartition : clonedPublishPartitions) {
+            PublishPartition cloned = publishPartition.clone();
+            for (String column : cloned.getColumns()) {
+                int columnIndex = event.getSchema().getColumnIndex(column);
+                if (columnIndex < 0) {
+                    LOG.warn("Column {} is not found in stream {}", column, cloned.getStreamId());
+                    continue;
+                }
+                cloned.getColumnValues().add(event.getData()[columnIndex]);
+            }
+
+            synchronized (outputLock) {
+                streamContext.counter().scope("alert_count").incr();
+                delegate.emit(Arrays.asList(cloned, event));
+            }
         }
     }
 
@@ -49,6 +77,16 @@ public class AlertBoltOutputCollectorWrapper implements AlertStreamCollector {
 
     @Override
     public void close() {
-
     }
+
+    public synchronized void onAlertBoltSpecChange(Collection<PublishPartition> addedPublishPartitions,
+                                                   Collection<PublishPartition> removedPublishPartitions,
+                                                   Collection<PublishPartition> modifiedPublishPartitions) {
+        Set<PublishPartition> clonedPublishPartitions = new HashSet<>(publishPartitions);
+        clonedPublishPartitions.addAll(addedPublishPartitions);
+        clonedPublishPartitions.removeAll(removedPublishPartitions);
+        clonedPublishPartitions.addAll(modifiedPublishPartitions);
+        publishPartitions = clonedPublishPartitions;
+    }
+
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/AlertPublisher.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/AlertPublisher.java
@@ -16,11 +16,13 @@
  */
 package org.apache.eagle.alert.engine.publisher;
 
-import org.apache.eagle.alert.engine.model.AlertStreamEvent;
-import com.typesafe.config.Config;
-
 import java.io.Serializable;
 import java.util.Map;
+
+import org.apache.eagle.alert.engine.coordinator.PublishPartition;
+import org.apache.eagle.alert.engine.model.AlertStreamEvent;
+
+import com.typesafe.config.Config;
 
 public interface AlertPublisher extends AlertPublishListener, Serializable {
     @SuppressWarnings("rawtypes")
@@ -28,7 +30,8 @@ public interface AlertPublisher extends AlertPublishListener, Serializable {
 
     String getName();
 
-    void nextEvent(AlertStreamEvent event);
+    void nextEvent(PublishPartition partition, AlertStreamEvent event);
 
     void close();
+
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AbstractPublishPlugin.java
@@ -18,7 +18,6 @@ package org.apache.eagle.alert.engine.publisher.impl;
 
 import com.google.common.base.Joiner;
 import com.typesafe.config.Config;
-import javafx.scene.control.Alert;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.eagle.alert.engine.codec.IEventSerializer;
 import org.apache.eagle.alert.engine.coordinator.OverrideDeduplicatorSpec;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertPublisherImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/publisher/impl/AlertPublisherImpl.java
@@ -17,17 +17,15 @@
 
 package org.apache.eagle.alert.engine.publisher.impl;
 
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.eagle.alert.engine.coordinator.PublishPartition;
 import org.apache.eagle.alert.engine.coordinator.Publishment;
 import org.apache.eagle.alert.engine.model.AlertStreamEvent;
 import org.apache.eagle.alert.engine.publisher.AlertPublishPlugin;
@@ -35,7 +33,6 @@ import org.apache.eagle.alert.engine.publisher.AlertPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
 import com.typesafe.config.Config;
 
 @SuppressWarnings("rawtypes")
@@ -44,12 +41,9 @@ public class AlertPublisherImpl implements AlertPublisher {
     private static final long serialVersionUID = 4809983246198138865L;
     private static final Logger LOG = LoggerFactory.getLogger(AlertPublisherImpl.class);
 
-    private static final String STREAM_NAME_DEFAULT = "_default";
-
     private final String name;
 
-    private volatile Map<String, Set<String>> psPublishPluginMapping = new ConcurrentHashMap<>(1);
-    private volatile Map<String, AlertPublishPlugin> publishPluginMapping = new ConcurrentHashMap<>(1);
+    private volatile Map<PublishPartition, AlertPublishPlugin> publishPluginMapping = new ConcurrentHashMap<>(1);
     private Config config;
     private Map conf;
 
@@ -69,42 +63,30 @@ public class AlertPublisherImpl implements AlertPublisher {
     }
 
     @Override
-    public void nextEvent(AlertStreamEvent event) {
+    public void nextEvent(PublishPartition partition, AlertStreamEvent event) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(event.toString());
         }
-        notifyAlert(event);
+        notifyAlert(partition, event);
     }
 
-    private void notifyAlert(AlertStreamEvent event) {
-        String policyId = event.getPolicyId();
-        if (StringUtils.isEmpty(policyId)) {
-            LOG.warn("policyId cannot be null for event to be published");
+    private void notifyAlert(PublishPartition partition, AlertStreamEvent event) {
+        // remove the column values for publish plugin match
+        partition.getColumnValues().clear();
+        if (!publishPluginMapping.containsKey(partition)) {
+            LOG.warn("PublishPartition {} is not found in publish plugin map", partition);
             return;
         }
-        // use default stream name if specified stream publisher is not found
-        Set<String> pubIds = psPublishPluginMapping.get(getPolicyStreamUniqueId(policyId, event.getStreamId()));
-        if (pubIds == null) {
-            pubIds = psPublishPluginMapping.get(getPolicyStreamUniqueId(policyId));
-        }
-        if (pubIds == null) {
-            LOG.warn("Policy {} Stream {} does *NOT* subscribe any publishment!", policyId, event.getStreamId());
+        AlertPublishPlugin plugin = publishPluginMapping.get(partition);
+        if (plugin == null) {
+            LOG.warn("PublishPartition {} has problems while initializing publish plugin", partition);
             return;
         }
-        event.ensureAlertId();
-        for (String pubId : pubIds) {
-            @SuppressWarnings("resource")
-            AlertPublishPlugin plugin = pubId != null ? publishPluginMapping.get(pubId) : null;
-            if (plugin == null) {
-                LOG.warn("Policy {} does *NOT* subscribe any publishment!", policyId);
-                continue;
-            }
-            try {
-                LOG.debug("Execute alert publisher {}", plugin.getClass().getCanonicalName());
-                plugin.onAlert(event);
-            } catch (Exception ex) {
-                LOG.error("Fail invoking publisher's onAlert, continue ", ex);
-            }
+        try {
+            LOG.debug("Execute alert publisher {}", plugin.getClass().getCanonicalName());
+            plugin.onAlert(event);
+        } catch (Exception ex) {
+            LOG.error("Fail invoking publisher's onAlert, continue ", ex);
         }
     }
 
@@ -137,8 +119,7 @@ public class AlertPublisherImpl implements AlertPublisher {
         }
 
         // copy and swap to avoid concurrency issue
-        Map<String, Set<String>> newPSPublishPluginMapping = new HashMap<>(psPublishPluginMapping);
-        Map<String, AlertPublishPlugin> newPublishMap = new HashMap<>(publishPluginMapping);
+        Map<PublishPartition, AlertPublishPlugin> newPublishMap = new HashMap<>(publishPluginMapping);
 
         // added
         for (Publishment publishment : added) {
@@ -146,8 +127,9 @@ public class AlertPublisherImpl implements AlertPublisher {
 
             AlertPublishPlugin plugin = AlertPublishPluginsFactory.createNotificationPlugin(publishment, config, conf);
             if (plugin != null) {
-                newPublishMap.put(publishment.getName(), plugin);
-                addPublishmentPoliciesStreams(newPSPublishPluginMapping, publishment.getPolicyIds(), publishment.getStreamIds(), publishment.getName());
+                for (PublishPartition p : getPublishPartitions(publishment)) {
+                    newPublishMap.put(p, plugin);
+                }
             } else {
                 LOG.error("OnPublishChange alertPublisher {} failed due to invalid format", publishment);
             }
@@ -155,37 +137,60 @@ public class AlertPublisherImpl implements AlertPublisher {
         //removed
         List<AlertPublishPlugin> toBeClosed = new ArrayList<>();
         for (Publishment publishment : removed) {
-            String pubName = publishment.getName();
-            removePublihsPoliciesStreams(newPSPublishPluginMapping, publishment.getPolicyIds(), pubName);
-            toBeClosed.add(newPublishMap.get(pubName));
-            newPublishMap.remove(publishment.getName());
+            AlertPublishPlugin plugin = null;
+            for (PublishPartition p : getPublishPartitions(publishment)) {
+                if (plugin == null) {
+                    plugin = newPublishMap.remove(p);
+                } else {
+                    newPublishMap.remove(p);
+                }
+            }
+            if (plugin != null) {
+                toBeClosed.add(plugin);
+            }
         }
         // updated
-        for (int i = 0; i < afterModified.size(); i++) {
-            String pubName = afterModified.get(i).getName();
-            List<String> newPolicies = afterModified.get(i).getPolicyIds();
-            List<String> newStreams = afterModified.get(i).getStreamIds();
-            List<String> oldPolicies = beforeModified.get(i).getPolicyIds();
-            List<String> oldStreams = beforeModified.get(i).getStreamIds();
-
-            if (!newPolicies.equals(oldPolicies) || !Objects.equal(newStreams, oldStreams)) {
-                // since both policy & stream may change, skip the compare and difference update
-                removePublihsPoliciesStreams(newPSPublishPluginMapping, oldPolicies, pubName);
-                addPublishmentPoliciesStreams(newPSPublishPluginMapping, newPolicies, newStreams, pubName);
-            }
-            Publishment newPub = afterModified.get(i);
-
+        for (Publishment publishment : afterModified) {
             // for updated publishment, need to init them too
-            AlertPublishPlugin newPlugin = AlertPublishPluginsFactory.createNotificationPlugin(newPub, config, conf);
-            newPublishMap.replace(pubName, newPlugin);
+            AlertPublishPlugin newPlugin = AlertPublishPluginsFactory.createNotificationPlugin(publishment, config, conf);
+            if (newPlugin != null) {
+                AlertPublishPlugin plugin = null;
+                for (PublishPartition p : getPublishPartitions(publishment)) {
+                    if (plugin == null) {
+                        plugin = newPublishMap.get(p);
+                    }
+                    newPublishMap.put(p, newPlugin);
+                }
+                if (plugin != null) {
+                    toBeClosed.add(plugin);
+                }
+            } else {
+                LOG.error("OnPublishChange alertPublisher {} failed due to invalid format", publishment);
+            }
         }
 
         // now do the swap
         publishPluginMapping = newPublishMap;
-        psPublishPluginMapping = newPSPublishPluginMapping;
 
         // safely close : it depend on plugin to check if want to wait all data to be flushed.
         closePlugins(toBeClosed);
+    }
+
+    private Set<PublishPartition> getPublishPartitions(Publishment publish) {
+        List<String> streamIds = new ArrayList<>();
+        // add the publish to the bolt
+        if (publish.getStreamIds() == null || publish.getStreamIds().size() <= 0) {
+            streamIds.add(Publishment.STREAM_NAME_DEFAULT);
+        } else {
+            streamIds.addAll(publish.getStreamIds());
+        }
+        Set<PublishPartition> publishPartitions = new HashSet<>();
+        for (String streamId : streamIds) {
+            for (String policyId : publish.getPolicyIds()) {
+                publishPartitions.add(new PublishPartition(streamId, policyId, publish.getName(), publish.getPartitionColumns()));
+            }
+        }
+        return publishPartitions;
     }
 
     private void closePlugins(List<AlertPublishPlugin> toBeClosed) {
@@ -193,56 +198,9 @@ public class AlertPublisherImpl implements AlertPublisher {
             try {
                 p.close();
             } catch (Exception e) {
-                LOG.error(MessageFormat.format("Error when close publish plugin {}, {}!", p.getClass().getCanonicalName()), e);
+                LOG.error(String.format("Error when close publish plugin {}!", p.getClass().getCanonicalName()), e);
             }
         }
-    }
-
-    private void addPublishmentPoliciesStreams(Map<String, Set<String>> newPSPublishPluginMapping,
-                                               List<String> addedPolicyIds, List<String> addedStreamIds, String pubName) {
-        if (addedPolicyIds == null || pubName == null) {
-            return;
-        }
-
-        if (addedStreamIds == null || addedStreamIds.size() <= 0) {
-            addedStreamIds = new ArrayList<String>();
-            addedStreamIds.add(STREAM_NAME_DEFAULT);
-        }
-
-        for (String policyId : addedPolicyIds) {
-            for (String streamId : addedStreamIds) {
-                String psUniqueId = getPolicyStreamUniqueId(policyId, streamId);
-                newPSPublishPluginMapping.putIfAbsent(psUniqueId, new HashSet<>());
-                newPSPublishPluginMapping.get(psUniqueId).add(pubName);
-            }
-        }
-    }
-
-    private synchronized void removePublihsPoliciesStreams(Map<String, Set<String>> newPSPublishPluginMapping,
-                                                           List<String> deletedPolicyIds, String pubName) {
-        if (deletedPolicyIds == null || pubName == null) {
-            return;
-        }
-
-        for (String policyId : deletedPolicyIds) {
-            for (Entry<String, Set<String>> entry : newPSPublishPluginMapping.entrySet()) {
-                if (entry.getKey().startsWith("policyId:" + policyId)) {
-                    entry.getValue().remove(pubName);
-                    break;
-                }
-            }
-        }
-    }
-
-    private String getPolicyStreamUniqueId(String policyId) {
-        return getPolicyStreamUniqueId(policyId, STREAM_NAME_DEFAULT);
-    }
-
-    private String getPolicyStreamUniqueId(String policyId, String streamId) {
-        if (StringUtils.isBlank(streamId)) {
-            streamId = STREAM_NAME_DEFAULT;
-        }
-        return String.format("policyId:%s,streamId:%s", policyId, streamId);
     }
 
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/AlertBoltSpecListener.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/router/AlertBoltSpecListener.java
@@ -19,10 +19,10 @@
 
 package org.apache.eagle.alert.engine.router;
 
+import java.util.Map;
+
 import org.apache.eagle.alert.coordination.model.AlertBoltSpec;
 import org.apache.eagle.alert.engine.coordinator.StreamDefinition;
-
-import java.util.Map;
 
 /**
  * Since 5/2/16.

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/UnitTopologyRunner.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/UnitTopologyRunner.java
@@ -205,8 +205,7 @@ public class UnitTopologyRunner {
         // connect alert bolt and alert publish bolt, this is the last bolt in the pipeline
         BoltDeclarer boltDeclarer = builder.setBolt(alertPublishBoltName, publisherBolt, numOfPublishExecutors).setNumTasks(numOfPublishTasks);
         for (int i = 0; i < numOfAlertBolts; i++) {
-            //boltDeclarer.fieldsGrouping(alertBoltNamePrefix + i, new Fields(AlertConstants.FIELD_0));
-            boltDeclarer.shuffleGrouping(alertBoltNamePrefix + i);
+            boltDeclarer.fieldsGrouping(alertBoltNamePrefix + i, new Fields(AlertConstants.FIELD_0));
         }
 
         return builder.createTopology();

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/resources/publishments2.json
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/resources/publishments2.json
@@ -19,6 +19,7 @@
       "mail.connection": "tls",
       "mail.smtp.port": "587"
     },
-    "dedupIntervalMin": "PT0M"
+    "dedupIntervalMin": "PT0M",
+    "serializer": "org.apache.eagle.alert.engine.publisher.impl.StringEventSerializer"
   }
 ]


### PR DESCRIPTION
Currently the publish is using shuffle grouping, we cannot enable parallelism for publish since we may have local cache which is unavailable across the storm cluster. We are going to use field group function to partition streams for publish bolt parallelism.
