### PR TITLE
EAGLE-796 MRJobEntityCreationHandler flush need N times

### DIFF
--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobEntityCreationHandler.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobEntityCreationHandler.java
@@ -104,7 +104,7 @@ public class MRJobEntityCreationHandler {
                 }
             }
         }
-        if(!success) {
+        if (!success) {
             LOG.warn("Fail flushing entities after tries {} times", MAX_RETRY_COUNT);
             return false;
         }

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobEntityCreationHandler.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobEntityCreationHandler.java
@@ -82,7 +82,6 @@ public class MRJobEntityCreationHandler {
             return createEntities(client);
         } catch (Exception e) {
             LOG.warn("exception found when flush entities, {}", e);
-            e.printStackTrace();
             return false;
         } finally {
             client.getJerseyClient().destroy();

--- a/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/parser/MRJobParserTest.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/parser/MRJobParserTest.java
@@ -401,6 +401,8 @@ public class MRJobParserTest {
         Assert.assertTrue(curator.checkExists().forPath(ZK_APP_PATH) == null);
         Assert.assertTrue(entities.isEmpty());
         verify(client, times(2)).create(any());
+        verify(client, times(2)).getJerseyClient();
+        verify(client, times(1)).close();
 
     }
 

--- a/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/parser/MRJobParserTest.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/parser/MRJobParserTest.java
@@ -346,8 +346,18 @@ public class MRJobParserTest {
 
 
     @Test
-    public void testMRJobParserFetchJobCountFailButRMalive() throws Exception {
+    public void testMRJobParserFetchJobCountFailButRMaliveRetry() throws Exception {
         setupMock();
+        reset(client);
+        client = mock(EagleServiceClientImpl.class);
+        MRRunningJobConfig.EagleServiceConfig eagleServiceConfig = mrRunningJobConfig.getEagleServiceConfig();
+        PowerMockito.whenNew(EagleServiceClientImpl.class).withArguments(
+            eagleServiceConfig.eagleServiceHost,
+            eagleServiceConfig.eagleServicePort,
+            eagleServiceConfig.username,
+            eagleServiceConfig.password).thenReturn(client);
+        when(client.create(any())).thenThrow(Exception.class).thenReturn(null);
+        when(client.getJerseyClient()).thenReturn(new Client());
         mockInputJobSteam("/mrjob_30784.json", JOB_URL);
         mockInputJobSteamWithException(JOB_COUNT_URL);
         mockGetConnection("/mrconf_30784.xml");
@@ -390,7 +400,7 @@ public class MRJobParserTest {
         Assert.assertTrue(curator.checkExists().forPath(ZK_JOB_PATH) == null);
         Assert.assertTrue(curator.checkExists().forPath(ZK_APP_PATH) == null);
         Assert.assertTrue(entities.isEmpty());
-        verify(client, times(1)).create(any());
+        verify(client, times(2)).create(any());
 
     }
 


### PR DESCRIPTION
EAGLE-796 MRJobEntityCreationHandler flush need N times
- It will retry until flushing has succeeded or tried more than 3 times.

https://issues.apache.org/jira/browse/EAGLE-796