### PR TITLE
[MINOR] Sleep 1 ms after versionId was generated

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
@@ -35,6 +35,7 @@ import org.apache.eagle.alert.metadata.resource.OpResult;
 import org.junit.*;
 import static org.powermock.api.mockito.PowerMockito.*;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ import java.io.IOException;
 import java.util.*;
 
 @RunWith(PowerMockRunner.class)
+@PrepareForTest({System.class})
 public class JdbcImplTest {
     private static Logger LOG = LoggerFactory.getLogger(JdbcImplTest.class);
     static IMetadataDao dao;
@@ -154,6 +156,8 @@ public class JdbcImplTest {
     }
 
     private void test_addstate() {
+        mockStatic(System.class);
+        when(System.currentTimeMillis()).thenReturn(1480502564700L);
         ScheduleState state = new ScheduleState();
         String versionId = "state-" + System.currentTimeMillis();
         state.setVersion(versionId);
@@ -184,6 +188,7 @@ public class JdbcImplTest {
         for (int i = 0; i < 10; i++) {
             ScheduleState state = new ScheduleState();
             String versionId = "state-" + System.currentTimeMillis();
+            System.out.println(versionId);
             state.setVersion(versionId);
             state.setGenerateTime(String.valueOf(new Date().getTime()));
             dao.addScheduleState(state);
@@ -196,6 +201,10 @@ public class JdbcImplTest {
         Assert.assertTrue(scheduleStates.size() == maxCapacity);
         List<String> TargetVersions = new ArrayList<>();
         scheduleStates.stream().forEach(state -> TargetVersions.add(state.getVersion()));
+
+        System.out.println(reservedOnes);
+        System.out.println(TargetVersions);
+
         Assert.assertTrue(CollectionUtils.isEqualCollection(reservedOnes, TargetVersions));
     }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
@@ -188,7 +188,6 @@ public class JdbcImplTest {
         for (int i = 0; i < 10; i++) {
             ScheduleState state = new ScheduleState();
             String versionId = "state-" + System.currentTimeMillis();
-            System.out.println(versionId);
             state.setVersion(versionId);
             state.setGenerateTime(String.valueOf(new Date().getTime()));
             dao.addScheduleState(state);
@@ -201,10 +200,6 @@ public class JdbcImplTest {
         Assert.assertTrue(scheduleStates.size() == maxCapacity);
         List<String> TargetVersions = new ArrayList<>();
         scheduleStates.stream().forEach(state -> TargetVersions.add(state.getVersion()));
-
-        System.out.println(reservedOnes);
-        System.out.println(TargetVersions);
-
         Assert.assertTrue(CollectionUtils.isEqualCollection(reservedOnes, TargetVersions));
     }
 }

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
@@ -184,6 +184,11 @@ public class JdbcImplTest {
             if (i >= 10 - maxCapacity) {
                 reservedOnes.add(versionId);
             }
+            try {
+                Thread.sleep(1);
+            } catch (Exception e) {
+
+            }
         }
         dao.clearScheduleState(maxCapacity);
         List<ScheduleState> scheduleStates = dao.listScheduleStates();

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
@@ -33,12 +33,15 @@ import org.apache.eagle.alert.metadata.IMetadataDao;
 
 import org.apache.eagle.alert.metadata.resource.OpResult;
 import org.junit.*;
+import static org.powermock.api.mockito.PowerMockito.*;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.*;
 
+@RunWith(PowerMockRunner.class)
 public class JdbcImplTest {
     private static Logger LOG = LoggerFactory.getLogger(JdbcImplTest.class);
     static IMetadataDao dao;
@@ -173,6 +176,9 @@ public class JdbcImplTest {
 
     @Test
     public void test_clearScheduleState() {
+        mockStatic(System.class);
+        when(System.currentTimeMillis()).thenReturn(1480502564800L, 1480502564801L, 1480502564802L, 1480502564803L, 1480502564804L,
+            1480502564805L, 1480502564806L, 1480502564807L, 1480502564808L, 1480502564809L);
         int maxCapacity = 4;
         List<String> reservedOnes = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
@@ -183,11 +189,6 @@ public class JdbcImplTest {
             dao.addScheduleState(state);
             if (i >= 10 - maxCapacity) {
                 reservedOnes.add(versionId);
-            }
-            try {
-                Thread.sleep(1);
-            } catch (Exception e) {
-
             }
         }
         dao.clearScheduleState(maxCapacity);

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/test/java/org/apache/eagle/alert/metadata/impl/JdbcImplTest.java
@@ -33,17 +33,12 @@ import org.apache.eagle.alert.metadata.IMetadataDao;
 
 import org.apache.eagle.alert.metadata.resource.OpResult;
 import org.junit.*;
-import static org.powermock.api.mockito.PowerMockito.*;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({System.class})
 public class JdbcImplTest {
     private static Logger LOG = LoggerFactory.getLogger(JdbcImplTest.class);
     static IMetadataDao dao;
@@ -156,8 +151,6 @@ public class JdbcImplTest {
     }
 
     private void test_addstate() {
-        mockStatic(System.class);
-        when(System.currentTimeMillis()).thenReturn(1480502564700L);
         ScheduleState state = new ScheduleState();
         String versionId = "state-" + System.currentTimeMillis();
         state.setVersion(versionId);
@@ -180,14 +173,11 @@ public class JdbcImplTest {
 
     @Test
     public void test_clearScheduleState() {
-        mockStatic(System.class);
-        when(System.currentTimeMillis()).thenReturn(1480502564800L, 1480502564801L, 1480502564802L, 1480502564803L, 1480502564804L,
-            1480502564805L, 1480502564806L, 1480502564807L, 1480502564808L, 1480502564809L);
         int maxCapacity = 4;
         List<String> reservedOnes = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             ScheduleState state = new ScheduleState();
-            String versionId = "state-" + System.currentTimeMillis();
+            String versionId = "state-" + (System.currentTimeMillis() + i);
             state.setVersion(versionId);
             state.setGenerateTime(String.valueOf(new Date().getTime()));
             dao.addScheduleState(state);
@@ -200,6 +190,8 @@ public class JdbcImplTest {
         Assert.assertTrue(scheduleStates.size() == maxCapacity);
         List<String> TargetVersions = new ArrayList<>();
         scheduleStates.stream().forEach(state -> TargetVersions.add(state.getVersion()));
+        LOG.debug(reservedOnes.toString());
+        LOG.debug(TargetVersions.toString());
         Assert.assertTrue(CollectionUtils.isEqualCollection(reservedOnes, TargetVersions));
     }
 }


### PR DESCRIPTION
[MINOR] Sleep 1 ms after versionId was generated
- VersionId is the same with one generated in last loop randomly, the test failed in this case.