### PR TITLE
[MINOR] avoid adding duplicated publishment in spec

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/PublishSpec.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/coordination/model/PublishSpec.java
@@ -17,6 +17,9 @@
 package org.apache.eagle.alert.coordination.model;
 
 import org.apache.eagle.alert.engine.coordinator.Publishment;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,8 +40,11 @@ public class PublishSpec {
         this.boltId = boltId;
     }
 
+    @JsonIgnore
     public void addPublishment(Publishment p) {
-        this.publishments.add(p);
+        if (!this.publishments.contains(p)) {
+            this.publishments.add(p);
+        }
     }
 
     public String getTopologyName() {


### PR DESCRIPTION
Although duplicated publisher won't impact anything since we convert it to map and publisher name is the key, avoid duplicated publisher in schedule state is meaningful.