### PR TITLE
EAGLE-824: Multiple policies in one alert bolt produces duplicated tuples

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/AlertBoltOutputCollectorWrapper.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/evaluator/impl/AlertBoltOutputCollectorWrapper.java
@@ -53,7 +53,11 @@ public class AlertBoltOutputCollectorWrapper implements AlertStreamCollector {
     public void emit(AlertStreamEvent event) {
         Set<PublishPartition> clonedPublishPartitions = new HashSet<>(publishPartitions);
         for (PublishPartition publishPartition : clonedPublishPartitions) {
+            // skip the publish partition which is not belong to this policy
             PublishPartition cloned = publishPartition.clone();
+            if (!cloned.getPolicyId().equalsIgnoreCase(event.getPolicyId())) {
+                continue;
+            }
             for (String column : cloned.getColumns()) {
                 int columnIndex = event.getSchema().getColumnIndex(column);
                 if (columnIndex < 0) {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/AlertBolt.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/runner/AlertBolt.java
@@ -197,16 +197,16 @@ public class AlertBolt extends AbstractStreamBolt implements AlertBoltSpecListen
         policyGroupEvaluator.onPolicyChange(comparator.getAdded(), comparator.getRemoved(), comparator.getModified(), sds);
 
         // update alert output collector
-        Set<PublishPartition> tempPublishPartitions = new HashSet<>();
+        Set<PublishPartition> newPublishPartitions = new HashSet<>();
         spec.getPublishPartitions().forEach(p -> {
             if (newPolicies.stream().filter(o -> o.getName().equals(p.getPolicyId())).count() > 0) {
-                tempPublishPartitions.add(p);
+                newPublishPartitions.add(p);
             }
         });
 
-        Collection<PublishPartition> addedPublishPartitions = CollectionUtils.subtract(tempPublishPartitions, cachedPublishPartitions);
-        Collection<PublishPartition> removedPublishPartitions = CollectionUtils.subtract(cachedPublishPartitions, tempPublishPartitions);
-        Collection<PublishPartition> modifiedPublishPartitions = CollectionUtils.intersection(tempPublishPartitions, cachedPublishPartitions);
+        Collection<PublishPartition> addedPublishPartitions = CollectionUtils.subtract(newPublishPartitions, cachedPublishPartitions);
+        Collection<PublishPartition> removedPublishPartitions = CollectionUtils.subtract(cachedPublishPartitions, newPublishPartitions);
+        Collection<PublishPartition> modifiedPublishPartitions = CollectionUtils.intersection(newPublishPartitions, cachedPublishPartitions);
 
         LOG.debug("added PublishPartition " + addedPublishPartitions);
         LOG.debug("removed PublishPartition " + removedPublishPartitions);
@@ -216,6 +216,7 @@ public class AlertBolt extends AbstractStreamBolt implements AlertBoltSpecListen
 
         // switch
         cachedPolicies = newPoliciesMap;
+        cachedPublishPartitions = newPublishPartitions;
         sdf = sds;
         specVersion = spec.getVersion();
         this.spec = spec;

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/router/CustomizedHandler.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/test/java/org/apache/eagle/alert/engine/router/CustomizedHandler.java
@@ -30,6 +30,7 @@ import java.util.Map;
  */
 public class CustomizedHandler implements PolicyStreamHandler {
     private Collector<AlertStreamEvent> collector;
+    private PolicyHandlerContext context;
 
     public CustomizedHandler(Map<String, StreamDefinition> sds) {
     }
@@ -37,11 +38,14 @@ public class CustomizedHandler implements PolicyStreamHandler {
     @Override
     public void prepare(Collector<AlertStreamEvent> collector, PolicyHandlerContext context) throws Exception {
         this.collector = collector;
+        this.context = context;
     }
 
     @Override
     public void send(StreamEvent event) throws Exception {
-        this.collector.emit(new AlertStreamEvent());
+	AlertStreamEvent alert = new AlertStreamEvent();
+	alert.setPolicyId(context.getPolicyDefinition().getName());
+        this.collector.emit(alert);
     }
 
     @Override

--- a/eagle-core/eagle-app/eagle-app-base/src/test/java/org/apache/eagle/app/stream/CEPFunctionTest.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/test/java/org/apache/eagle/app/stream/CEPFunctionTest.java
@@ -54,7 +54,7 @@ public class CEPFunctionTest {
             put("name","cpu.usage");
             put("value", 0.96);
         }});
-        Assert.assertTrue("Should get result in 5 s", semaphore.tryAcquire(5, TimeUnit.SECONDS));
+        Assert.assertTrue("Should get result in 5 s", semaphore.tryAcquire(15, TimeUnit.SECONDS));
         function.close();
     }
 }


### PR DESCRIPTION
Multiple policies in one alert bolt will cause each policy in this bolt produce the tuple and emit tuple into publisher, the publisher will got multiple duplicated tuples.