### PR TITLE
EAGLE-828 CuratorFramework should be closed after it was created by applications

### DIFF
--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/recover/MRRunningJobManager.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/recover/MRRunningJobManager.java
@@ -18,12 +18,11 @@
 
 package org.apache.eagle.jpm.mr.running.recover;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.eagle.jpm.mr.running.MRRunningJobConfig;
 import org.apache.eagle.jpm.mr.runningentity.JobExecutionAPIEntity;
 import org.apache.eagle.jpm.util.jobrecover.RunningJobManager;
 import org.apache.eagle.jpm.util.resourcefetch.model.AppInfo;
-
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -34,7 +33,7 @@ public class MRRunningJobManager implements Serializable {
 
     public MRRunningJobManager(MRRunningJobConfig.ZKStateConfig config) {
         this.runningJobManager = new RunningJobManager(config.zkQuorum,
-                config.zkSessionTimeoutMs, config.zkRetryTimes, config.zkRetryInterval, config.zkRoot, config.zkLockPath);
+            config.zkSessionTimeoutMs, config.zkRetryTimes, config.zkRetryInterval, config.zkRoot, config.zkLockPath);
     }
 
     public Map<String, JobExecutionAPIEntity> recoverYarnApp(String appId) throws Exception {
@@ -78,5 +77,9 @@ public class MRRunningJobManager implements Serializable {
 
     public void delete(String yarnAppId, String jobId) {
         this.runningJobManager.delete(yarnAppId, jobId);
+    }
+
+    public void close() {
+        this.runningJobManager.close();
     }
 }

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/storm/MRRunningJobFetchSpout.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/storm/MRRunningJobFetchSpout.java
@@ -174,5 +174,6 @@ public class MRRunningJobFetchSpout extends BaseRichSpout {
 
     @Override
     public void close() {
+        this.runningJobManager.close();
     }
 }

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/storm/MRRunningJobParseBolt.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/storm/MRRunningJobParseBolt.java
@@ -113,5 +113,6 @@ public class MRRunningJobParseBolt extends BaseRichBolt {
     @Override
     public void cleanup() {
         super.cleanup();
+        runningJobManager.close();
     }
 }

--- a/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/MRRunningJobManagerTest.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/MRRunningJobManagerTest.java
@@ -137,7 +137,6 @@ public class MRRunningJobManagerTest {
     }
 
     @Test
-    @Ignore
     public void testMRRunningJobManagerRecoverYarnAppWithLock() throws Exception {
         Assert.assertTrue(curator.checkExists().forPath(SHARE_RESOURCES) != null);
         curator.setData().forPath(SHARE_RESOURCES, generateZkSetData());
@@ -167,6 +166,7 @@ public class MRRunningJobManagerTest {
     }
 
     @Test
+    @Ignore
     public void testMRRunningJobManagerRecoverWithLock() throws Exception {
         Assert.assertTrue(curator.checkExists().forPath(SHARE_RESOURCES) != null);
         curator.setData().forPath(SHARE_RESOURCES, generateZkSetData());

--- a/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/TestMRRunningJobApplicationStorm.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/test/java/org/apache/eagle/jpm/mr/running/TestMRRunningJobApplicationStorm.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.apache.eagle.jpm.mr.running;
+
+
+import backtype.storm.Config;
+import backtype.storm.Testing;
+import backtype.storm.generated.StormTopology;
+import backtype.storm.testing.CompleteTopologyParam;
+import backtype.storm.testing.FeederSpout;
+import backtype.storm.testing.MkClusterParam;
+import backtype.storm.testing.MockedSources;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Values;
+import com.typesafe.config.ConfigFactory;
+import junit.framework.Assert;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.apache.eagle.jpm.mr.running.storm.MRRunningJobParseBolt;
+import org.apache.eagle.jpm.util.Constants;
+import org.apache.eagle.jpm.util.resourcefetch.model.AppInfo;
+import org.apache.eagle.jpm.util.resourcefetch.model.AppsWrapper;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import static org.mockito.Mockito.*;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CuratorFrameworkFactory.class})
+@PowerMockIgnore({"javax.*"})
+public class TestMRRunningJobApplicationStorm {
+    private static final ObjectMapper OBJ_MAPPER = new ObjectMapper();
+    private static TestingServer zk;
+    private CuratorFramework curator;
+    @Test
+    public void testCleanUpWasInvoked() throws Exception {
+        zk = new TestingServer();
+        MkClusterParam mkClusterParam = new MkClusterParam();
+        mkClusterParam.setSupervisors(4);
+        Config daemonConf = new Config();
+        daemonConf.put(Config.STORM_LOCAL_MODE_ZMQ, false);
+        daemonConf.put(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS, true);
+        mkClusterParam.setDaemonConf(daemonConf);
+
+        com.typesafe.config.Config config = ConfigFactory.load();
+        MRRunningJobConfig mrRunningJobConfig = MRRunningJobConfig.newInstance(config);
+        mrRunningJobConfig.getZkStateConfig().zkQuorum = zk.getConnectString();
+        List<String> conKeyKeys = makeConfKeyKeys(mrRunningJobConfig);
+
+        MRRunningJobParseBolt mrRunningJobParseBolt = new MRRunningJobParseBolt(
+            mrRunningJobConfig.getEagleServiceConfig(),
+            mrRunningJobConfig.getEndpointConfig(),
+            mrRunningJobConfig.getZkStateConfig(),
+            conKeyKeys,
+            config
+        );
+
+        curator = CuratorFrameworkFactory.newClient(zk.getConnectString(), new RetryOneTime(1));
+        PowerMockito.mockStatic(CuratorFrameworkFactory.class);
+        when(CuratorFrameworkFactory.newClient(anyString(), anyInt(), anyInt(), anyObject())).thenReturn(curator);
+
+        String spoutName = "fakeMRRunningJobFetchSpout";
+        Testing.withSimulatedTimeLocalCluster(mkClusterParam, iLocalCluster -> {
+            TopologyBuilder builder = new TopologyBuilder();
+            builder.setSpout(spoutName, new FeederSpout(new Fields("appId", "appInfo", "mrJobEntity")), 1).setNumTasks(1);
+            builder.setBolt("mrRunningJobParseBolt", mrRunningJobParseBolt, 1).setNumTasks(1).fieldsGrouping(spoutName, new Fields("appId"));
+            StormTopology topology = builder.createTopology();
+            MockedSources mockedSources = new MockedSources();
+            InputStream previousmrrunningapp = this.getClass().getResourceAsStream("/previousmrrunningapp.json");
+            AppsWrapper appsWrapper = OBJ_MAPPER.readValue(previousmrrunningapp, AppsWrapper.class);
+            List<AppInfo> appInfos = appsWrapper.getApps().getApp();
+            mockedSources.addMockData(spoutName, new Values(appInfos.get(0).getId(), appInfos.get(0), null));
+
+            CompleteTopologyParam completeTopologyParam = new CompleteTopologyParam();
+            completeTopologyParam.setMockedSources(mockedSources);
+            Config conf = new Config();
+            conf.setMessageTimeoutSecs(20);
+            conf.setNumWorkers(2);
+            completeTopologyParam.setStormConf(conf);
+            Testing.completeTopology(iLocalCluster, topology, completeTopologyParam);
+
+            Assert.assertEquals(curator.getState(), CuratorFrameworkState.STOPPED);
+        } );
+    }
+
+    private List<String> makeConfKeyKeys(MRRunningJobConfig mrRunningJobConfig) {
+        String[] confKeyPatternsSplit = mrRunningJobConfig.getConfig().getString("MRConfigureKeys.jobConfigKey").split(",");
+        List<String> confKeyKeys = new ArrayList<>(confKeyPatternsSplit.length);
+        for (String confKeyPattern : confKeyPatternsSplit) {
+            confKeyKeys.add(confKeyPattern.trim());
+        }
+        confKeyKeys.add(Constants.JobConfiguration.CASCADING_JOB);
+        confKeyKeys.add(Constants.JobConfiguration.HIVE_JOB);
+        confKeyKeys.add(Constants.JobConfiguration.PIG_JOB);
+        confKeyKeys.add(Constants.JobConfiguration.SCOOBI_JOB);
+        confKeyKeys.add(0, mrRunningJobConfig.getConfig().getString("MRConfigureKeys.jobNameKey"));
+        return confKeyKeys;
+    }
+}

--- a/eagle-jpm/eagle-jpm-spark-running/src/main/java/org/apache/eagle/jpm/spark/running/recover/SparkRunningJobManager.java
+++ b/eagle-jpm/eagle-jpm-spark-running/src/main/java/org/apache/eagle/jpm/spark/running/recover/SparkRunningJobManager.java
@@ -78,4 +78,8 @@ public class SparkRunningJobManager implements Serializable {
     public void delete(String yarnAppId, String jobId) {
         this.runningJobManager.delete(yarnAppId, jobId);
     }
+
+    public void close() {
+        this.runningJobManager.close();
+    }
 }

--- a/eagle-jpm/eagle-jpm-spark-running/src/main/java/org/apache/eagle/jpm/spark/running/storm/SparkRunningJobFetchSpout.java
+++ b/eagle-jpm/eagle-jpm-spark-running/src/main/java/org/apache/eagle/jpm/spark/running/storm/SparkRunningJobFetchSpout.java
@@ -175,6 +175,7 @@ public class SparkRunningJobFetchSpout extends BaseRichSpout {
 
     @Override
     public void close() {
+        this.sparkRunningJobManager.close();
 
     }
 }

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/jobrecover/RunningJobManager.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/jobrecover/RunningJobManager.java
@@ -65,6 +65,7 @@ public class RunningJobManager implements Serializable {
         LOG.info("InterProcessMutex lock path is " + lockPath);
         lock = new InterProcessMutex(curator, lockPath);
         try {
+            lock.acquire();
             if (curator.checkExists().forPath(this.zkRoot) == null) {
                 curator.create()
                     .creatingParentsIfNeeded()
@@ -73,6 +74,12 @@ public class RunningJobManager implements Serializable {
             }
         } catch (Exception e) {
             LOG.warn("{}", e);
+        } finally {
+            try {
+                lock.release();
+            } catch (Exception e) {
+                LOG.error("fail releasing lock", e);
+            }
         }
     }
 

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/jobrecover/RunningJobManager.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/jobrecover/RunningJobManager.java
@@ -65,7 +65,6 @@ public class RunningJobManager implements Serializable {
         LOG.info("InterProcessMutex lock path is " + lockPath);
         lock = new InterProcessMutex(curator, lockPath);
         try {
-            lock.acquire();
             if (curator.checkExists().forPath(this.zkRoot) == null) {
                 curator.create()
                     .creatingParentsIfNeeded()
@@ -74,12 +73,6 @@ public class RunningJobManager implements Serializable {
             }
         } catch (Exception e) {
             LOG.warn("{}", e);
-        } finally {
-            try {
-                lock.release();
-            } catch (Exception e) {
-                LOG.error("fail releasing lock", e);
-            }
         }
     }
 

--- a/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/jobrecover/RunningJobManager.java
+++ b/eagle-jpm/eagle-jpm-util/src/main/java/org/apache/eagle/jpm/util/jobrecover/RunningJobManager.java
@@ -18,19 +18,23 @@
 
 package org.apache.eagle.jpm.util.jobrecover;
 
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
-import org.apache.eagle.jpm.util.resourcefetch.model.AppInfo;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.retry.RetryNTimes;
+import org.apache.eagle.jpm.util.resourcefetch.model.AppInfo;
 import org.apache.zookeeper.CreateMode;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class RunningJobManager implements Serializable {
     public static final Logger LOG = LoggerFactory.getLogger(RunningJobManager.class);
@@ -43,10 +47,10 @@ public class RunningJobManager implements Serializable {
 
     private CuratorFramework newCurator(String zkQuorum, int zkSessionTimeoutMs, int zkRetryTimes, int zkRetryInterval) {
         return CuratorFrameworkFactory.newClient(
-                zkQuorum,
-                zkSessionTimeoutMs,
-                15000,
-                new RetryNTimes(zkRetryTimes, zkRetryInterval)
+            zkQuorum,
+            zkSessionTimeoutMs,
+            15000,
+            new RetryNTimes(zkRetryTimes, zkRetryInterval)
         );
     }
 
@@ -63,9 +67,9 @@ public class RunningJobManager implements Serializable {
         try {
             if (curator.checkExists().forPath(this.zkRoot) == null) {
                 curator.create()
-                        .creatingParentsIfNeeded()
-                        .withMode(CreateMode.PERSISTENT)
-                        .forPath(this.zkRoot);
+                    .creatingParentsIfNeeded()
+                    .withMode(CreateMode.PERSISTENT)
+                    .forPath(this.zkRoot);
             }
         } catch (Exception e) {
             LOG.warn("{}", e);
@@ -201,9 +205,9 @@ public class RunningJobManager implements Serializable {
             JSONObject object = new JSONObject(fields);
             if (curator.checkExists().forPath(path) == null) {
                 curator.create()
-                        .creatingParentsIfNeeded()
-                        .withMode(CreateMode.PERSISTENT)
-                        .forPath(path);
+                    .creatingParentsIfNeeded()
+                    .withMode(CreateMode.PERSISTENT)
+                    .forPath(path);
             }
             curator.setData().forPath(path, object.toString().getBytes("UTF-8"));
 
@@ -298,13 +302,19 @@ public class RunningJobManager implements Serializable {
         try {
             if (curator.checkExists().forPath(path) == null) {
                 curator.create()
-                        .creatingParentsIfNeeded()
-                        .withMode(CreateMode.PERSISTENT)
-                        .forPath(path);
+                    .creatingParentsIfNeeded()
+                    .withMode(CreateMode.PERSISTENT)
+                    .forPath(path);
             }
             curator.setData().forPath(path, lastFinishTime.toString().getBytes("UTF-8"));
         } catch (Exception e) {
             LOG.error("failed to update last finish time {}", e);
+        }
+    }
+
+    public void close() {
+        if (curator != null) {
+            curator.close();
         }
     }
 }

--- a/eagle-security/eagle-security-hive/src/main/java/org/apache/eagle/security/hive/jobrunning/HiveJobFetchSpout.java
+++ b/eagle-security/eagle-security-hive/src/main/java/org/apache/eagle/security/hive/jobrunning/HiveJobFetchSpout.java
@@ -285,4 +285,9 @@ public class HiveJobFetchSpout extends BaseRichSpout {
     public void fail(Object msgId) {
         //process fail over later
     }
+
+    @Override
+    public void close() {
+        this.runningJobManager.close();
+    }
 }


### PR DESCRIPTION
EAGLE-828 CuratorFramework should be closed after it was created by applications

- Add close method in dependent apps.
- Add ut for the close method, make sure curatorFramework has be closed.

https://issues.apache.org/jira/browse/EAGLE-828