### PR TITLE
[EAGLE-837] Stream definition change does not reflect in AlertBolt

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/StreamColumn.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/StreamColumn.java
@@ -21,8 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Objects;
+
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class StreamColumn implements Serializable {
 
@@ -37,6 +41,34 @@ public class StreamColumn implements Serializable {
     public String toString() {
         return String.format("StreamColumn=name[%s], type=[%s], defaultValue=[%s], required=[%s], nodataExpression=[%s]",
             name, type, defaultValue, required, nodataExpression);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+            .append(this.name)
+            .append(this.type)
+            .append(this.defaultValue)
+            .append(this.required)
+            .append(this.description)
+            .append(this.nodataExpression)
+            .build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StreamColumn)) {
+            return false;
+        }
+        return Objects.equals(this.name, ((StreamColumn) obj).name)
+            && Objects.equals(this.type, ((StreamColumn) obj).type)
+            && Objects.equals(this.defaultValue, ((StreamColumn) obj).defaultValue)
+            && Objects.equals(this.required, ((StreamColumn) obj).required)
+            && Objects.equals(this.description, ((StreamColumn) obj).description)
+            && Objects.equals(this.nodataExpression, ((StreamColumn) obj).nodataExpression);
     }
 
     public String getNodataExpression() {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/StreamDefinition.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/coordinator/StreamDefinition.java
@@ -18,9 +18,14 @@ package org.apache.eagle.alert.engine.coordinator;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This is actually a data source schema.
@@ -60,6 +65,36 @@ public class StreamDefinition implements Serializable {
             validate,
             timeseries,
             columns);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+            .append(this.streamId)
+            .append(this.description)
+            .append(this.validate)
+            .append(this.timeseries)
+            .append(this.dataSource)
+            .append(this.siteId)
+            .append(this.columns)
+            .build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StreamDefinition)) {
+            return false;
+        }
+        return Objects.equals(this.streamId, ((StreamDefinition) obj).streamId)
+            && Objects.equals(this.description, ((StreamDefinition) obj).description)
+            && Objects.equals(this.validate, ((StreamDefinition) obj).validate)
+            && Objects.equals(this.timeseries, ((StreamDefinition) obj).timeseries)
+            && Objects.equals(this.dataSource, ((StreamDefinition) obj).dataSource)
+            && Objects.equals(this.siteId, ((StreamDefinition) obj).siteId)
+            && CollectionUtils.isEqualCollection(this.columns, ((StreamDefinition) obj).columns);
     }
 
     public String getStreamId() {

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/test/java/org/apache/eagle/alert/engine/coordinator/StreamDefinitionTest.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/test/java/org/apache/eagle/alert/engine/coordinator/StreamDefinitionTest.java
@@ -45,8 +45,8 @@ public class StreamDefinitionTest {
         StreamDefinition streamDefinition1 = streamDefinition.copy();
         Assert.assertEquals("StreamDefinition[streamId=null, dataSource=null, description=null, validate=false, timeseries=false, columns=[StreamColumn=name[name], type=[string], defaultValue=[null], required=[false], nodataExpression=[null], StreamColumn=name[host], type=[string], defaultValue=[null], required=[false], nodataExpression=[null], StreamColumn=name[flag], type=[bool], defaultValue=[null], required=[false], nodataExpression=[null], StreamColumn=name[data], type=[long], defaultValue=[null], required=[false], nodataExpression=[null], StreamColumn=name[value], type=[double], defaultValue=[null], required=[false], nodataExpression=[null]]", streamDefinition1.toString());
 
-        Assert.assertFalse(streamDefinition1.equals(streamDefinition));
+        Assert.assertTrue(streamDefinition1.equals(streamDefinition));
         Assert.assertFalse(streamDefinition1 == streamDefinition);
-        Assert.assertFalse(streamDefinition1.hashCode() == streamDefinition.hashCode());
+        Assert.assertTrue(streamDefinition1.hashCode() == streamDefinition.hashCode());
     }
 }


### PR DESCRIPTION
Stream definition change only trigger router bolt & publisher update, we don't update corresponding alert bolt stream definition references. It will cause alert bolt still use old stream definition references, it could produce array index out of bound exception.